### PR TITLE
Improve DB/IMAP concurrency to prevent API stalls

### DIFF
--- a/dwata-agents/src/bin/financial_extractor.rs
+++ b/dwata-agents/src/bin/financial_extractor.rs
@@ -276,7 +276,7 @@ fn load_email_from_db(conn: Arc<Mutex<Connection>>, email_id: i64) -> Result<(St
 fn load_active_patterns(conn: Arc<Mutex<Connection>>) -> Result<Vec<FinancialPattern>> {
     let conn = conn.lock().unwrap();
     let mut stmt = match conn.prepare(
-        "SELECT id, name, regex_pattern, description, document_type, status, confidence,\n                amount_group, vendor_group, source_vendor_group, destination_vendor_group,\n                date_group, reference_group, is_default, is_active,\n                match_count, last_matched_at, created_at, updated_at\n         FROM financial_patterns\n         WHERE is_active = true",
+        "SELECT id, name, regex_pattern, description, sender_email, document_type, status, confidence,\n                amount_group, vendor_group, source_vendor_group, destination_vendor_group,\n                date_group, reference_group, is_default, is_active,\n                match_count, last_matched_at, created_at, updated_at\n         FROM financial_patterns\n         WHERE is_active = true",
     ) {
         Ok(stmt) => stmt,
         Err(_) => {
@@ -291,6 +291,7 @@ fn load_active_patterns(conn: Arc<Mutex<Connection>>) -> Result<Vec<FinancialPat
                         name: row.get(1)?,
                         regex_pattern: row.get(2)?,
                         description: row.get(3)?,
+                        sender_email: None,
                         document_type: row.get(4)?,
                         status: row.get(5)?,
                         confidence: row.get(6)?,
@@ -321,21 +322,22 @@ fn load_active_patterns(conn: Arc<Mutex<Connection>>) -> Result<Vec<FinancialPat
                 name: row.get(1)?,
                 regex_pattern: row.get(2)?,
                 description: row.get(3)?,
-                document_type: row.get(4)?,
-                status: row.get(5)?,
-                confidence: row.get(6)?,
-                amount_group: row.get::<_, i64>(7)? as usize,
-                vendor_group: row.get::<_, Option<i64>>(8)?.map(|v| v as usize),
-                source_vendor_group: row.get::<_, Option<i64>>(9)?.map(|v| v as usize),
-                destination_vendor_group: row.get::<_, Option<i64>>(10)?.map(|v| v as usize),
-                date_group: row.get::<_, Option<i64>>(11)?.map(|v| v as usize),
-                reference_group: row.get::<_, Option<i64>>(12)?.map(|v| v as usize),
-                is_default: row.get(13)?,
-                is_active: row.get(14)?,
-                match_count: row.get(15)?,
-                last_matched_at: row.get(16)?,
-                created_at: row.get(17)?,
-                updated_at: row.get(18)?,
+                sender_email: row.get(4)?,
+                document_type: row.get(5)?,
+                status: row.get(6)?,
+                confidence: row.get(7)?,
+                amount_group: row.get::<_, i64>(8)? as usize,
+                vendor_group: row.get::<_, Option<i64>>(9)?.map(|v| v as usize),
+                source_vendor_group: row.get::<_, Option<i64>>(10)?.map(|v| v as usize),
+                destination_vendor_group: row.get::<_, Option<i64>>(11)?.map(|v| v as usize),
+                date_group: row.get::<_, Option<i64>>(12)?.map(|v| v as usize),
+                reference_group: row.get::<_, Option<i64>>(13)?.map(|v| v as usize),
+                is_default: row.get(14)?,
+                is_active: row.get(15)?,
+                match_count: row.get(16)?,
+                last_matched_at: row.get(17)?,
+                created_at: row.get(18)?,
+                updated_at: row.get(19)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;

--- a/dwata-api/src/database/credentials.rs
+++ b/dwata-api/src/database/credentials.rs
@@ -1,5 +1,6 @@
 use crate::database::AsyncDbConnection;
 use shared_types::credential::{CredentialMetadata, CredentialType, CreateCredentialRequest};
+use tokio::task;
 
 #[derive(Debug)]
 pub enum CredentialDbError {
@@ -26,87 +27,156 @@ pub async fn insert_credential(
     conn: AsyncDbConnection,
     request: &CreateCredentialRequest,
 ) -> Result<CredentialMetadata, CredentialDbError> {
-    let conn = conn.lock().await;
-    let now = chrono::Utc::now().timestamp_millis();
+    let credential_type = request.credential_type.clone();
+    let identifier = request.identifier.clone();
+    let username = request.username.clone();
+    let service_name = request.service_name.clone();
+    let port = request.port;
+    let use_tls = request.use_tls;
+    let notes = request.notes.clone();
+    let extra_metadata = request.extra_metadata.clone();
 
-    let mut stmt = conn
-        .prepare("SELECT COUNT(*) FROM credentials_metadata WHERE identifier = ?")
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let now = chrono::Utc::now().timestamp_millis();
 
-    let count: i64 = stmt
-        .query_row([&request.identifier], |row| row.get(0))
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT COUNT(*) FROM credentials_metadata WHERE identifier = ?")
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    if count > 0 {
-        return Err(CredentialDbError::DuplicateIdentifier);
-    }
+        let count: i64 = stmt
+            .query_row([&identifier], |row| row.get(0))
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    let id: i64 = conn
-        .query_row(
-            "INSERT INTO credentials_metadata
-             (credential_type, identifier, username, service_name, port, use_tls, notes,
-              created_at, updated_at, is_active, extra_metadata)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-             RETURNING id",
-            rusqlite::params![
-                request.credential_type.as_str(),
-                &request.identifier,
-                &request.username,
-                &request.service_name,
-                &request.port,
-                &request.use_tls.unwrap_or(true),
-                &request.notes,
-                now,
-                now,
-                true,
-                &request.extra_metadata,
-            ],
-            |row| row.get(0),
-        )
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        if count > 0 {
+            return Err(CredentialDbError::DuplicateIdentifier);
+        }
 
-    Ok(CredentialMetadata {
-        id,
-        credential_type: request.credential_type.clone(),
-        identifier: request.identifier.clone(),
-        username: request.username.clone(),
-        service_name: request.service_name.clone(),
-        port: request.port,
-        use_tls: request.use_tls,
-        notes: request.notes.clone(),
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: None,
-        is_active: true,
-        extra_metadata: request.extra_metadata.clone(),
+        let id: i64 = conn
+            .query_row(
+                "INSERT INTO credentials_metadata
+                 (credential_type, identifier, username, service_name, port, use_tls, notes,
+                  created_at, updated_at, is_active, extra_metadata)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 RETURNING id",
+                rusqlite::params![
+                    credential_type.as_str(),
+                    &identifier,
+                    &username,
+                    &service_name,
+                    &port,
+                    &use_tls.unwrap_or(true),
+                    &notes,
+                    now,
+                    now,
+                    true,
+                    &extra_metadata,
+                ],
+                |row| row.get(0),
+            )
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+
+        Ok(CredentialMetadata {
+            id,
+            credential_type,
+            identifier,
+            username,
+            service_name,
+            port,
+            use_tls,
+            notes,
+            created_at: now,
+            updated_at: now,
+            last_accessed_at: None,
+            is_active: true,
+            extra_metadata,
+        })
     })
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 pub async fn list_credentials(
     conn: AsyncDbConnection,
     include_inactive: bool,
 ) -> Result<Vec<CredentialMetadata>, CredentialDbError> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let query = if include_inactive {
+            "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
+                    created_at, updated_at, last_accessed_at, is_active, extra_metadata
+             FROM credentials_metadata
+             ORDER BY created_at DESC"
+        } else {
+            "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
+                    created_at, updated_at, last_accessed_at, is_active, extra_metadata
+             FROM credentials_metadata
+             WHERE is_active = true
+             ORDER BY created_at DESC"
+        };
 
-    let query = if include_inactive {
-        "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
-                created_at, updated_at, last_accessed_at, is_active, extra_metadata
-         FROM credentials_metadata
-         ORDER BY created_at DESC"
-    } else {
-        "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
-                created_at, updated_at, last_accessed_at, is_active, extra_metadata
-         FROM credentials_metadata
-         WHERE is_active = true
-         ORDER BY created_at DESC"
-    };
+        let mut stmt = conn
+            .prepare(query)
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    let mut stmt = conn
-        .prepare(query)
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| {
+                let credential_type_str: String = row.get(1)?;
+                let credential_type = match credential_type_str.as_str() {
+                    "imap" => CredentialType::Imap,
+                    "smtp" => CredentialType::Smtp,
+                    "oauth" => CredentialType::OAuth,
+                    "apikey" => CredentialType::ApiKey,
+                    "database" => CredentialType::Database,
+                    "localfile" => CredentialType::LocalFile,
+                    _ => CredentialType::Custom,
+                };
 
-    let rows = stmt
-        .query_map([], |row| {
+                Ok(CredentialMetadata {
+                    id: row.get(0)?,
+                    credential_type,
+                    identifier: row.get(2)?,
+                    username: row.get(3)?,
+                    service_name: row.get(4)?,
+                    port: row.get(5)?,
+                    use_tls: row.get(6)?,
+                    notes: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                    last_accessed_at: row.get(10)?,
+                    is_active: row.get(11)?,
+                    extra_metadata: row.get(12)?,
+                })
+            })
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+
+        let mut credentials = Vec::new();
+        for row in rows {
+            credentials.push(row.map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?);
+        }
+
+        Ok(credentials)
+    })
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
+}
+
+pub async fn get_credential(
+    conn: AsyncDbConnection,
+    id: i64,
+) -> Result<CredentialMetadata, CredentialDbError> {
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
+                        created_at, updated_at, last_accessed_at, is_active, extra_metadata
+                 FROM credentials_metadata
+                 WHERE id = ?",
+            )
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+
+        stmt.query_row([id], |row| {
             let credential_type_str: String = row.get(1)?;
             let credential_type = match credential_type_str.as_str() {
                 "imap" => CredentialType::Imap,
@@ -114,7 +184,6 @@ pub async fn list_credentials(
                 "oauth" => CredentialType::OAuth,
                 "apikey" => CredentialType::ApiKey,
                 "database" => CredentialType::Database,
-                "localfile" => CredentialType::LocalFile,
                 _ => CredentialType::Custom,
             };
 
@@ -134,78 +203,33 @@ pub async fn list_credentials(
                 extra_metadata: row.get(12)?,
             })
         })
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
-
-    let mut credentials = Vec::new();
-    for row in rows {
-        credentials.push(row.map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?);
-    }
-
-    Ok(credentials)
-}
-
-pub async fn get_credential(
-    conn: AsyncDbConnection,
-    id: i64,
-) -> Result<CredentialMetadata, CredentialDbError> {
-    let conn = conn.lock().await;
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
-                    created_at, updated_at, last_accessed_at, is_active, extra_metadata
-             FROM credentials_metadata
-             WHERE id = ?",
-        )
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
-
-    stmt.query_row([id], |row| {
-        let credential_type_str: String = row.get(1)?;
-        let credential_type = match credential_type_str.as_str() {
-            "imap" => CredentialType::Imap,
-            "smtp" => CredentialType::Smtp,
-            "oauth" => CredentialType::OAuth,
-            "apikey" => CredentialType::ApiKey,
-            "database" => CredentialType::Database,
-            _ => CredentialType::Custom,
-        };
-
-        Ok(CredentialMetadata {
-            id: row.get(0)?,
-            credential_type,
-            identifier: row.get(2)?,
-            username: row.get(3)?,
-            service_name: row.get(4)?,
-            port: row.get(5)?,
-            use_tls: row.get(6)?,
-            notes: row.get(7)?,
-            created_at: row.get(8)?,
-            updated_at: row.get(9)?,
-            last_accessed_at: row.get(10)?,
-            is_active: row.get(11)?,
-            extra_metadata: row.get(12)?,
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => CredentialDbError::NotFound,
+            _ => CredentialDbError::DatabaseError(e.to_string()),
         })
     })
-    .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => CredentialDbError::NotFound,
-        _ => CredentialDbError::DatabaseError(e.to_string()),
-    })
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 pub async fn update_last_accessed(
     conn: AsyncDbConnection,
     id: i64,
 ) -> Result<(), CredentialDbError> {
-    let conn = conn.lock().await;
-    let now = chrono::Utc::now().timestamp_millis();
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let now = chrono::Utc::now().timestamp_millis();
 
-    conn.execute(
-        "UPDATE credentials_metadata SET last_accessed_at = ? WHERE id = ?",
-        rusqlite::params![now, id],
-    )
-    .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        conn.execute(
+            "UPDATE credentials_metadata SET last_accessed_at = ? WHERE id = ?",
+            rusqlite::params![now, id],
+        )
+        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    Ok(())
+        Ok(())
+    })
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 pub async fn update_credential(
@@ -218,126 +242,137 @@ pub async fn update_credential(
     notes: Option<String>,
     extra_metadata: Option<String>,
 ) -> Result<CredentialMetadata, CredentialDbError> {
-    let conn = conn.lock().await;
-    let now = chrono::Utc::now().timestamp_millis();
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let now = chrono::Utc::now().timestamp_millis();
 
-    let mut updates = vec!["updated_at = ?".to_string()];
-    let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(now)];
+        let mut updates = vec!["updated_at = ?".to_string()];
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(now)];
 
-    if username.is_some() {
-        updates.push("username = ?".to_string());
-        params.push(Box::new(username.clone()));
-    }
-    if service_name.is_some() {
-        updates.push("service_name = ?".to_string());
-        params.push(Box::new(service_name.clone()));
-    }
-    if port.is_some() {
-        updates.push("port = ?".to_string());
-        params.push(Box::new(port));
-    }
-    if use_tls.is_some() {
-        updates.push("use_tls = ?".to_string());
-        params.push(Box::new(use_tls));
-    }
-    if notes.is_some() {
-        updates.push("notes = ?".to_string());
-        params.push(Box::new(notes.clone()));
-    }
-    if extra_metadata.is_some() {
-        updates.push("extra_metadata = ?".to_string());
-        params.push(Box::new(extra_metadata.clone()));
-    }
+        if username.is_some() {
+            updates.push("username = ?".to_string());
+            params.push(Box::new(username.clone()));
+        }
+        if service_name.is_some() {
+            updates.push("service_name = ?".to_string());
+            params.push(Box::new(service_name.clone()));
+        }
+        if port.is_some() {
+            updates.push("port = ?".to_string());
+            params.push(Box::new(port));
+        }
+        if use_tls.is_some() {
+            updates.push("use_tls = ?".to_string());
+            params.push(Box::new(use_tls));
+        }
+        if notes.is_some() {
+            updates.push("notes = ?".to_string());
+            params.push(Box::new(notes.clone()));
+        }
+        if extra_metadata.is_some() {
+            updates.push("extra_metadata = ?".to_string());
+            params.push(Box::new(extra_metadata.clone()));
+        }
 
-    params.push(Box::new(id));
+        params.push(Box::new(id));
 
-    let query = format!(
-        "UPDATE credentials_metadata SET {} WHERE id = ?",
-        updates.join(", ")
-    );
+        let query = format!(
+            "UPDATE credentials_metadata SET {} WHERE id = ?",
+            updates.join(", ")
+        );
 
-    let params_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let params_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
 
-    conn.execute(&query, params_refs.as_slice())
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        conn.execute(&query, params_refs.as_slice())
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
-                    created_at, updated_at, last_accessed_at, is_active, extra_metadata
-             FROM credentials_metadata
-             WHERE id = ?",
-        )
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, credential_type, identifier, username, service_name, port, use_tls, notes,
+                        created_at, updated_at, last_accessed_at, is_active, extra_metadata
+                 FROM credentials_metadata
+                 WHERE id = ?",
+            )
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    let credential = stmt.query_row([id], |row| {
-        let credential_type_str: String = row.get(1)?;
-        let credential_type = match credential_type_str.as_str() {
-            "imap" => CredentialType::Imap,
-            "smtp" => CredentialType::Smtp,
-            "oauth" => CredentialType::OAuth,
-            "apikey" => CredentialType::ApiKey,
-            "database" => CredentialType::Database,
-            _ => CredentialType::Custom,
-        };
+        let credential = stmt
+            .query_row([id], |row| {
+                let credential_type_str: String = row.get(1)?;
+                let credential_type = match credential_type_str.as_str() {
+                    "imap" => CredentialType::Imap,
+                    "smtp" => CredentialType::Smtp,
+                    "oauth" => CredentialType::OAuth,
+                    "apikey" => CredentialType::ApiKey,
+                    "database" => CredentialType::Database,
+                    _ => CredentialType::Custom,
+                };
 
-        Ok(CredentialMetadata {
-            id: row.get(0)?,
-            credential_type,
-            identifier: row.get(2)?,
-            username: row.get(3)?,
-            service_name: row.get(4)?,
-            port: row.get(5)?,
-            use_tls: row.get(6)?,
-            notes: row.get(7)?,
-            created_at: row.get(8)?,
-            updated_at: row.get(9)?,
-            last_accessed_at: row.get(10)?,
-            is_active: row.get(11)?,
-            extra_metadata: row.get(12)?,
-        })
+                Ok(CredentialMetadata {
+                    id: row.get(0)?,
+                    credential_type,
+                    identifier: row.get(2)?,
+                    username: row.get(3)?,
+                    service_name: row.get(4)?,
+                    port: row.get(5)?,
+                    use_tls: row.get(6)?,
+                    notes: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
+                    last_accessed_at: row.get(10)?,
+                    is_active: row.get(11)?,
+                    extra_metadata: row.get(12)?,
+                })
+            })
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => CredentialDbError::NotFound,
+                _ => CredentialDbError::DatabaseError(e.to_string()),
+            })?;
+
+        Ok(credential)
     })
-    .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => CredentialDbError::NotFound,
-        _ => CredentialDbError::DatabaseError(e.to_string()),
-    })?;
-
-    Ok(credential)
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 pub async fn soft_delete_credential(
     conn: AsyncDbConnection,
     id: i64,
 ) -> Result<(), CredentialDbError> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let rows_affected = conn
+            .execute(
+                "UPDATE credentials_metadata SET is_active = false WHERE id = ?",
+                [id],
+            )
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    let rows_affected = conn
-        .execute(
-            "UPDATE credentials_metadata SET is_active = false WHERE id = ?",
-            [id],
-        )
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        if rows_affected == 0 {
+            return Err(CredentialDbError::NotFound);
+        }
 
-    if rows_affected == 0 {
-        return Err(CredentialDbError::NotFound);
-    }
-
-    Ok(())
+        Ok(())
+    })
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 pub async fn hard_delete_credential(
     conn: AsyncDbConnection,
     id: i64,
 ) -> Result<(), CredentialDbError> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let rows_affected = conn
+            .execute("DELETE FROM credentials_metadata WHERE id = ?", [id])
+            .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
 
-    let rows_affected = conn
-        .execute("DELETE FROM credentials_metadata WHERE id = ?", [id])
-        .map_err(|e| CredentialDbError::DatabaseError(e.to_string()))?;
+        if rows_affected == 0 {
+            return Err(CredentialDbError::NotFound);
+        }
 
-    if rows_affected == 0 {
-        return Err(CredentialDbError::NotFound);
-    }
-
-    Ok(())
+        Ok(())
+    })
+    .await
+    .map_err(|e| CredentialDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }

--- a/dwata-api/src/database/downloads.rs
+++ b/dwata-api/src/database/downloads.rs
@@ -5,6 +5,7 @@ use shared_types::download::{
 use shared_types::email::EmailAddress;
 use std::fmt;
 use rusqlite::OptionalExtension;
+use tokio::task;
 
 pub use crate::database::AsyncDbConnection;
 
@@ -98,100 +99,104 @@ pub async fn get_download_job(
     conn: AsyncDbConnection,
     id: i64,
 ) -> Result<DownloadJob, DownloadDbError> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, source_type, credential_id, job_type, status, total_items, downloaded_items,
+                        failed_items, skipped_items, in_progress_items, bytes_downloaded,
+                        source_state, error_message, created_at, started_at, updated_at,
+                        completed_at, last_sync_at
+                 FROM download_jobs
+                 WHERE id = ?",
+            )
+            .map_err(|e| DownloadDbError::DatabaseError(e.to_string()))?;
 
-    let mut stmt = conn
-        .prepare(
-            "SELECT id, source_type, credential_id, job_type, status, total_items, downloaded_items,
-                    failed_items, skipped_items, in_progress_items, bytes_downloaded,
-                    source_state, error_message, created_at, started_at, updated_at,
-                    completed_at, last_sync_at
-             FROM download_jobs
-             WHERE id = ?",
-        )
-        .map_err(|e| DownloadDbError::DatabaseError(e.to_string()))?;
+        stmt.query_row([id], |row| {
+            let source_type_str: String = row.get(1)?;
+            let job_type_str: String = row.get(3)?;
 
-    stmt.query_row([id], |row| {
-        let source_type_str: String = row.get(1)?;
-        let job_type_str: String = row.get(3)?;
+            let source_type = match source_type_str.as_str() {
+                "imap" => SourceType::Imap,
+                "google-drive" => SourceType::GoogleDrive,
+                "dropbox" => SourceType::Dropbox,
+                "onedrive" => SourceType::OneDrive,
+                "local-file" => SourceType::LocalFile,
+                _ => SourceType::Imap,
+            };
 
-        let source_type = match source_type_str.as_str() {
-            "imap" => SourceType::Imap,
-            "google-drive" => SourceType::GoogleDrive,
-            "dropbox" => SourceType::Dropbox,
-            "onedrive" => SourceType::OneDrive,
-            "local-file" => SourceType::LocalFile,
-            _ => SourceType::Imap,
-        };
+            let job_type = match job_type_str.as_str() {
+                "recent-sync" => JobType::RecentSync,
+                "historical-backfill" => JobType::HistoricalBackfill,
+                _ => JobType::RecentSync,
+            };
 
-        let job_type = match job_type_str.as_str() {
-            "recent-sync" => JobType::RecentSync,
-            "historical-backfill" => JobType::HistoricalBackfill,
-            _ => JobType::RecentSync,
-        };
+            let status_str: String = row.get(4)?;
+            let status = match status_str.as_str() {
+                "pending" => DownloadJobStatus::Pending,
+                "running" => DownloadJobStatus::Running,
+                "paused" => DownloadJobStatus::Paused,
+                "completed" => DownloadJobStatus::Completed,
+                "failed" => DownloadJobStatus::Failed,
+                "cancelled" => DownloadJobStatus::Cancelled,
+                _ => DownloadJobStatus::Pending,
+            };
 
-        let status_str: String = row.get(4)?;
-        let status = match status_str.as_str() {
-            "pending" => DownloadJobStatus::Pending,
-            "running" => DownloadJobStatus::Running,
-            "paused" => DownloadJobStatus::Paused,
-            "completed" => DownloadJobStatus::Completed,
-            "failed" => DownloadJobStatus::Failed,
-            "cancelled" => DownloadJobStatus::Cancelled,
-            _ => DownloadJobStatus::Pending,
-        };
+            let total_items: i64 = row.get(5)?;
+            let downloaded_items: i64 = row.get(6)?;
+            let failed_items: i64 = row.get(7)?;
+            let skipped_items: i64 = row.get(8)?;
+            let in_progress_items: i64 = row.get(9)?;
 
-        let total_items: i64 = row.get(5)?;
-        let downloaded_items: i64 = row.get(6)?;
-        let failed_items: i64 = row.get(7)?;
-        let skipped_items: i64 = row.get(8)?;
-        let in_progress_items: i64 = row.get(9)?;
+            let remaining =
+                total_items.saturating_sub(downloaded_items + failed_items + skipped_items);
+            let percent = if total_items > 0 {
+                ((downloaded_items + skipped_items) as f32 / total_items as f32) * 100.0
+            } else {
+                0.0
+            };
 
-        let remaining = total_items.saturating_sub(downloaded_items + failed_items + skipped_items);
-        let percent = if total_items > 0 {
-            ((downloaded_items + skipped_items) as f32 / total_items as f32) * 100.0
-        } else {
-            0.0
-        };
+            let source_state_json: String = row.get(11)?;
+            let mut source_state: serde_json::Value =
+                serde_json::from_str(&source_state_json).unwrap_or(serde_json::json!({}));
+            if source_state.is_null() {
+                source_state = serde_json::json!({});
+            }
 
-        let source_state_json: String = row.get(11)?;
-        let mut source_state: serde_json::Value =
-            serde_json::from_str(&source_state_json).unwrap_or(serde_json::json!({}));
-        if source_state.is_null() {
-            source_state = serde_json::json!({});
-        }
-
-        Ok(DownloadJob {
-            id: row.get(0)?,
-            source_type,
-            credential_id: row.get(2)?,
-            job_type,
-            status,
-            progress: DownloadProgress {
-                total_items: total_items as u64,
-                downloaded_items: downloaded_items as u64,
-                failed_items: failed_items as u64,
-                skipped_items: skipped_items as u64,
-                in_progress_items: in_progress_items as u64,
-                remaining_items: remaining as u64,
-                percent_complete: percent,
-                bytes_downloaded: row.get(9)?,
-                items_per_second: 0.0,
-                estimated_completion_secs: None,
-            },
-            source_state,
-            error_message: row.get(12)?,
-            created_at: row.get(13)?,
-            started_at: row.get(14)?,
-            updated_at: row.get(15)?,
-            completed_at: row.get(16)?,
-            last_sync_at: row.get(17)?,
+            Ok(DownloadJob {
+                id: row.get(0)?,
+                source_type,
+                credential_id: row.get(2)?,
+                job_type,
+                status,
+                progress: DownloadProgress {
+                    total_items: total_items as u64,
+                    downloaded_items: downloaded_items as u64,
+                    failed_items: failed_items as u64,
+                    skipped_items: skipped_items as u64,
+                    in_progress_items: in_progress_items as u64,
+                    remaining_items: remaining as u64,
+                    percent_complete: percent,
+                    bytes_downloaded: row.get(9)?,
+                    items_per_second: 0.0,
+                    estimated_completion_secs: None,
+                },
+                source_state,
+                error_message: row.get(12)?,
+                created_at: row.get(13)?,
+                started_at: row.get(14)?,
+                updated_at: row.get(15)?,
+                completed_at: row.get(16)?,
+                last_sync_at: row.get(17)?,
+            })
+        })
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => DownloadDbError::NotFound,
+            _ => DownloadDbError::DatabaseError(e.to_string()),
         })
     })
-    .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => DownloadDbError::NotFound,
-        _ => DownloadDbError::DatabaseError(e.to_string()),
-    })
+    .await
+    .map_err(|e| DownloadDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 pub async fn list_download_jobs(
@@ -200,18 +205,18 @@ pub async fn list_download_jobs(
     limit: usize,
 ) -> Result<Vec<DownloadJob>, DownloadDbError> {
     let conn_ref = conn.clone();
+    let status = status_filter.map(|v| v.to_string());
+    let ids = task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let query = if let Some(status) = status {
+            format!(
+                "SELECT id FROM download_jobs WHERE status = '{}' ORDER BY created_at DESC LIMIT {}",
+                status, limit
+            )
+        } else {
+            format!("SELECT id FROM download_jobs ORDER BY created_at DESC LIMIT {}", limit)
+        };
 
-    let query = if let Some(status) = status_filter {
-        format!(
-            "SELECT id FROM download_jobs WHERE status = '{}' ORDER BY created_at DESC LIMIT {}",
-            status, limit
-        )
-    } else {
-        format!("SELECT id FROM download_jobs ORDER BY created_at DESC LIMIT {}", limit)
-    };
-
-    let ids = {
-        let conn = conn.lock().await;
         let mut stmt = conn
             .prepare(&query)
             .map_err(|e| DownloadDbError::DatabaseError(e.to_string()))?;
@@ -221,8 +226,11 @@ pub async fn list_download_jobs(
             .map_err(|e| DownloadDbError::DatabaseError(e.to_string()))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| DownloadDbError::DatabaseError(e.to_string()))?;
-        result
-    };
+
+        Ok(result)
+    })
+    .await
+    .map_err(|e| DownloadDbError::DatabaseError(format!("Blocking task failed: {}", e)))??;
     let mut jobs = Vec::new();
     for id in ids {
         if let Ok(job) = get_download_job(conn_ref.clone(), id).await {
@@ -429,151 +437,190 @@ pub async fn insert_email_download_transactional(
     size_bytes: Option<i32>,
     labels: &[String],
 ) -> Result<(i64, i64), DownloadDbError> {
-    let conn = conn.lock().await;
-    let now = chrono::Utc::now().timestamp_millis();
+    let message_id = message_id.map(|v| v.to_string());
+    let subject = subject.map(|v| v.to_string());
+    let from_address = from_address.to_string();
+    let from_name = from_name.map(|v| v.to_string());
+    let reply_to = reply_to.map(|v| v.to_string());
+    let body_text = body_text.map(|v| v.to_string());
+    let body_html = body_html.map(|v| v.to_string());
+    let to_addresses = to_addresses.to_vec();
+    let cc_addresses = cc_addresses.to_vec();
+    let bcc_addresses = bcc_addresses.to_vec();
+    let labels = labels.to_vec();
 
-    // Skip if we already have this UID for the folder
-    let existing_email_id: Option<i64> = conn.query_row(
-        "SELECT id FROM emails WHERE credential_id = ? AND folder_id = ? AND uid = ?",
-        rusqlite::params![credential_id, folder_id, uid as i32],
-        |row| row.get(0),
-    )
-    .optional()
-    .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to check existing email: {}", e)))?;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let now = chrono::Utc::now().timestamp_millis();
 
-    if let Some(email_id) = existing_email_id {
-        return Ok((0, email_id));
-    }
+        // Skip if we already have this UID for the folder
+        let existing_email_id: Option<i64> = conn
+            .query_row(
+                "SELECT id FROM emails WHERE credential_id = ? AND folder_id = ? AND uid = ?",
+                rusqlite::params![credential_id, folder_id, uid as i32],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| {
+                DownloadDbError::DatabaseError(format!("Failed to check existing email: {}", e))
+            })?;
 
-    // Begin transaction
-    conn.execute("BEGIN TRANSACTION", [])
-        .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to begin transaction: {}", e)))?;
+        if let Some(email_id) = existing_email_id {
+            return Ok((0, email_id));
+        }
 
-    let result = (|| -> Result<(i64, i64), DownloadDbError> {
-        // 1. Insert download_item
-        let metadata_json: Option<String> = None;
-        let download_item_id: i64 = conn.query_row(
-            "INSERT INTO download_items
-             (job_id, source_identifier, source_folder_id, item_type, status, size_bytes,
-               mime_type, metadata, created_at, updated_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-              RETURNING id",
-            rusqlite::params![
-                job_id as i32,
-                &uid.to_string(),
-                folder_id,
-                "email",
-                "completed",
-                size_bytes,
-                Some("message/rfc822"),
-                metadata_json.as_deref(),
-                now,
-                now
-            ],
-            |row| row.get(0)
-        ).map_err(|e| DownloadDbError::DatabaseError(format!("Failed to insert download_item: {}", e)))?;
+        // Begin transaction
+        conn.execute("BEGIN TRANSACTION", [])
+            .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to begin transaction: {}", e)))?;
 
-        // 2. Insert email
-        let to_json = serde_json::to_string(to_addresses)
-            .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to serialize to_addresses: {}", e)))?;
-        let cc_json = serde_json::to_string(cc_addresses)
-            .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to serialize cc_addresses: {}", e)))?;
-        let bcc_json = serde_json::to_string(bcc_addresses)
-            .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to serialize bcc_addresses: {}", e)))?;
+        let result = (|| -> Result<(i64, i64), DownloadDbError> {
+            // 1. Insert download_item
+            let metadata_json: Option<String> = None;
+            let download_item_id: i64 = conn
+                .query_row(
+                    "INSERT INTO download_items
+                     (job_id, source_identifier, source_folder_id, item_type, status, size_bytes,
+                       mime_type, metadata, created_at, updated_at)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                      RETURNING id",
+                    rusqlite::params![
+                        job_id as i32,
+                        &uid.to_string(),
+                        folder_id,
+                        "email",
+                        "completed",
+                        size_bytes,
+                        Some("message/rfc822"),
+                        metadata_json.as_deref(),
+                        now,
+                        now
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(|e| {
+                    DownloadDbError::DatabaseError(format!("Failed to insert download_item: {}", e))
+                })?;
 
-        let email_id: i64 = conn.query_row(
-            "INSERT INTO emails
-             (download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
-               to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
-               body_text, body_html, is_read, is_flagged, is_draft, is_answered,
-               has_attachments, attachment_count, size_bytes, thread_id, created_at, updated_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-              ON CONFLICT(credential_id, folder_id, uid) DO UPDATE SET
-                updated_at = excluded.updated_at
-              RETURNING id",
-            rusqlite::params![
-                download_item_id,
-                credential_id,
-                uid as i32,
-                folder_id,
-                message_id,
-                subject,
-                from_address,
-                from_name,
-                &to_json,
-                &cc_json,
-                &bcc_json,
-                reply_to,
-                date_sent,
-                date_received,
-                body_text,
-                body_html,
-                is_read,
-                is_flagged,
-                is_draft,
-                is_answered,
-                has_attachments,
-                attachment_count,
-                size_bytes,
-                None::<String>,
-                now,
-                now
-            ],
-            |row| row.get(0)
-        ).map_err(|e| DownloadDbError::DatabaseError(format!("Failed to insert email: {}", e)))?;
+            // 2. Insert email
+            let to_json = serde_json::to_string(&to_addresses).map_err(|e| {
+                DownloadDbError::DatabaseError(format!("Failed to serialize to_addresses: {}", e))
+            })?;
+            let cc_json = serde_json::to_string(&cc_addresses).map_err(|e| {
+                DownloadDbError::DatabaseError(format!("Failed to serialize cc_addresses: {}", e))
+            })?;
+            let bcc_json = serde_json::to_string(&bcc_addresses).map_err(|e| {
+                DownloadDbError::DatabaseError(format!("Failed to serialize bcc_addresses: {}", e))
+            })?;
 
-        // 3. Insert labels if present
-        for label_name in labels {
-            if !label_name.is_empty() {
-                let label_id: i64 = conn.query_row(
-                    "INSERT INTO email_labels (credential_id, name, label_type, created_at, updated_at)
-                     VALUES (?, ?, 'user', ?, ?)
-                     ON CONFLICT(credential_id, name) DO UPDATE SET
-                         updated_at = excluded.updated_at
-                     RETURNING id",
-                    rusqlite::params![credential_id, label_name, now, now],
-                    |row| row.get(0)
-                ).map_err(|e| DownloadDbError::DatabaseError(format!("Failed to get/create label: {}", e)))?;
+            let email_id: i64 = conn
+                .query_row(
+                    "INSERT INTO emails
+                     (download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
+                       to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
+                       body_text, body_html, is_read, is_flagged, is_draft, is_answered,
+                       has_attachments, attachment_count, size_bytes, thread_id, created_at, updated_at)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                      ON CONFLICT(credential_id, folder_id, uid) DO UPDATE SET
+                        updated_at = excluded.updated_at
+                      RETURNING id",
+                    rusqlite::params![
+                        download_item_id,
+                        credential_id,
+                        uid as i32,
+                        folder_id,
+                        message_id,
+                        subject,
+                        from_address,
+                        from_name,
+                        &to_json,
+                        &cc_json,
+                        &bcc_json,
+                        reply_to,
+                        date_sent,
+                        date_received,
+                        body_text,
+                        body_html,
+                        is_read,
+                        is_flagged,
+                        is_draft,
+                        is_answered,
+                        has_attachments,
+                        attachment_count,
+                        size_bytes,
+                        None::<String>,
+                        now,
+                        now
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to insert email: {}", e)))?;
 
-                // Insert label association
-                conn.execute(
-                    "INSERT OR IGNORE INTO email_label_associations (email_id, label_id, created_at)
-                     VALUES (?, ?, ?)",
-                    rusqlite::params![email_id, label_id, now],
-                ).map_err(|e| DownloadDbError::DatabaseError(format!("Failed to insert label association: {}", e)))?;
+            // 3. Insert labels if present
+            for label_name in &labels {
+                if !label_name.is_empty() {
+                    let label_id: i64 = conn
+                        .query_row(
+                            "INSERT INTO email_labels (credential_id, name, label_type, created_at, updated_at)
+                             VALUES (?, ?, 'user', ?, ?)
+                             ON CONFLICT(credential_id, name) DO UPDATE SET
+                                 updated_at = excluded.updated_at
+                             RETURNING id",
+                            rusqlite::params![credential_id, label_name, now, now],
+                            |row| row.get(0),
+                        )
+                        .map_err(|e| {
+                            DownloadDbError::DatabaseError(format!(
+                                "Failed to get/create label: {}",
+                                e
+                            ))
+                        })?;
+
+                    // Insert label association
+                    conn.execute(
+                        "INSERT OR IGNORE INTO email_label_associations (email_id, label_id, created_at)
+                         VALUES (?, ?, ?)",
+                        rusqlite::params![email_id, label_id, now],
+                    )
+                    .map_err(|e| {
+                        DownloadDbError::DatabaseError(format!(
+                            "Failed to insert label association: {}",
+                            e
+                        ))
+                    })?;
+                }
+            }
+
+            // 4. Update job progress (increment downloaded_items by 1)
+            conn.execute(
+                "UPDATE download_jobs
+                  SET downloaded_items = downloaded_items + 1,
+                      bytes_downloaded = bytes_downloaded + ?,
+                      updated_at = ?
+                  WHERE id = ?",
+                rusqlite::params![size_bytes.unwrap_or(0) as i64, now, job_id],
+            )
+            .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to update progress: {}", e)))?;
+
+            Ok((download_item_id, email_id))
+        })();
+
+        match result {
+            Ok(ids) => {
+                // Commit transaction
+                conn.execute("COMMIT", []).map_err(|e| {
+                    DownloadDbError::DatabaseError(format!("Failed to commit transaction: {}", e))
+                })?;
+                Ok(ids)
+            }
+            Err(e) => {
+                // Rollback transaction
+                let _ = conn.execute("ROLLBACK", []);
+                Err(e)
             }
         }
-
-        // 3. Update job progress (increment downloaded_items by 1)
-        conn.execute(
-            "UPDATE download_jobs
-              SET downloaded_items = downloaded_items + 1,
-                  bytes_downloaded = bytes_downloaded + ?,
-                  updated_at = ?
-              WHERE id = ?",
-            rusqlite::params![
-                size_bytes.unwrap_or(0) as i64,
-                now,
-                job_id
-            ],
-        ).map_err(|e| DownloadDbError::DatabaseError(format!("Failed to update progress: {}", e)))?;
-
-        Ok((download_item_id, email_id))
-    })();
-
-    match result {
-        Ok(ids) => {
-            // Commit transaction
-            conn.execute("COMMIT", [])
-                .map_err(|e| DownloadDbError::DatabaseError(format!("Failed to commit transaction: {}", e)))?;
-            Ok(ids)
-        }
-        Err(e) => {
-            // Rollback transaction
-            let _ = conn.execute("ROLLBACK", []);
-            Err(e)
-        }
-    }
+    })
+    .await
+    .map_err(|e| DownloadDbError::DatabaseError(format!("Blocking task failed: {}", e)))?
 }
 
 fn source_type_to_string(source_type: &SourceType) -> &'static str {

--- a/dwata-api/src/database/emails.rs
+++ b/dwata-api/src/database/emails.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use rusqlite::params_from_iter;
 use rusqlite::types::Value;
 use std::collections::HashSet;
+use tokio::task;
 
 #[derive(Debug, Clone)]
 pub struct EmailScanRow {
@@ -80,41 +81,45 @@ pub async fn filter_new_uids(
         return Ok(Vec::new());
     }
 
-    let conn = conn.lock().await;
-    let mut existing = HashSet::new();
-    let chunk_size = 900; // SQLite max variables is 999
+    let uids = uids.to_vec();
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut existing = HashSet::new();
+        let chunk_size = 900; // SQLite max variables is 999
 
-    for chunk in uids.chunks(chunk_size) {
-        let placeholders = std::iter::repeat("?")
-            .take(chunk.len())
-            .collect::<Vec<_>>()
-            .join(", ");
+        for chunk in uids.chunks(chunk_size) {
+            let placeholders = std::iter::repeat("?")
+                .take(chunk.len())
+                .collect::<Vec<_>>()
+                .join(", ");
 
-        let query = format!(
-            "SELECT uid FROM emails
-             WHERE credential_id = ? AND folder_id = ? AND uid IN ({})",
-            placeholders
-        );
+            let query = format!(
+                "SELECT uid FROM emails
+                 WHERE credential_id = ? AND folder_id = ? AND uid IN ({})",
+                placeholders
+            );
 
-        let mut params: Vec<rusqlite::types::Value> = Vec::with_capacity(2 + chunk.len());
-        params.push(rusqlite::types::Value::from(credential_id));
-        params.push(rusqlite::types::Value::from(folder_id));
-        params.extend(chunk.iter().map(|uid| rusqlite::types::Value::from(*uid as i64)));
+            let mut params: Vec<rusqlite::types::Value> = Vec::with_capacity(2 + chunk.len());
+            params.push(rusqlite::types::Value::from(credential_id));
+            params.push(rusqlite::types::Value::from(folder_id));
+            params.extend(chunk.iter().map(|uid| rusqlite::types::Value::from(*uid as i64)));
 
-        let mut stmt = conn.prepare(&query)?;
-        let rows = stmt.query_map(params_from_iter(params), |row| row.get::<_, i32>(0))?;
-        for row in rows {
-            existing.insert(row? as u32);
+            let mut stmt = conn.prepare(&query)?;
+            let rows = stmt.query_map(params_from_iter(params), |row| row.get::<_, i32>(0))?;
+            for row in rows {
+                existing.insert(row? as u32);
+            }
         }
-    }
 
-    let filtered = uids
-        .iter()
-        .copied()
-        .filter(|uid| !existing.contains(uid))
-        .collect();
+        let filtered = uids
+            .iter()
+            .copied()
+            .filter(|uid| !existing.contains(uid))
+            .collect();
 
-    Ok(filtered)
+        Ok(filtered)
+    })
+    .await?
 }
 
 /// Get the oldest UID already stored for a folder
@@ -140,54 +145,56 @@ pub async fn get_email(
     conn: AsyncDbConnection,
     email_id: i64,
 ) -> Result<Email> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
+                    to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
+                    body_text, body_html, is_read, is_flagged, is_draft, is_answered,
+                    has_attachments, attachment_count, size_bytes, thread_id,
+                    created_at, updated_at
+             FROM emails WHERE id = ?"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
-                to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
-                body_text, body_html, is_read, is_flagged, is_draft, is_answered,
-                has_attachments, attachment_count, size_bytes, thread_id,
-                created_at, updated_at
-         FROM emails WHERE id = ?"
-    )?;
+        let email = stmt.query_row([email_id], |row| {
+            let to_json: String = row.get(9)?;
+            let cc_json: String = row.get(10)?;
+            let bcc_json: String = row.get(11)?;
 
-    let email = stmt.query_row([email_id], |row| {
-        let to_json: String = row.get(9)?;
-        let cc_json: String = row.get(10)?;
-        let bcc_json: String = row.get(11)?;
+            Ok(Email {
+                id: row.get(0)?,
+                download_item_id: row.get(1)?,
+                credential_id: row.get(2)?,
+                uid: row.get::<_, i32>(3)? as u32,
+                folder_id: row.get(4)?,
+                message_id: row.get(5)?,
+                subject: row.get(6)?,
+                from_address: row.get(7)?,
+                from_name: row.get(8)?,
+                to_addresses: serde_json::from_str(&to_json).unwrap_or_default(),
+                cc_addresses: serde_json::from_str(&cc_json).unwrap_or_default(),
+                bcc_addresses: serde_json::from_str(&bcc_json).unwrap_or_default(),
+                reply_to: row.get(12)?,
+                date_sent: row.get(13)?,
+                date_received: row.get(14)?,
+                body_text: row.get(15)?,
+                body_html: row.get(16)?,
+                is_read: row.get(17)?,
+                is_flagged: row.get(18)?,
+                is_draft: row.get(19)?,
+                is_answered: row.get(20)?,
+                has_attachments: row.get(21)?,
+                attachment_count: row.get(22)?,
+                size_bytes: row.get(23)?,
+                thread_id: row.get(24)?,
+                created_at: row.get(25)?,
+                updated_at: row.get(26)?,
+            })
+        })?;
 
-        Ok(Email {
-            id: row.get(0)?,
-            download_item_id: row.get(1)?,
-            credential_id: row.get(2)?,
-            uid: row.get::<_, i32>(3)? as u32,
-            folder_id: row.get(4)?,
-            message_id: row.get(5)?,
-            subject: row.get(6)?,
-            from_address: row.get(7)?,
-            from_name: row.get(8)?,
-            to_addresses: serde_json::from_str(&to_json).unwrap_or_default(),
-            cc_addresses: serde_json::from_str(&cc_json).unwrap_or_default(),
-            bcc_addresses: serde_json::from_str(&bcc_json).unwrap_or_default(),
-            reply_to: row.get(12)?,
-            date_sent: row.get(13)?,
-            date_received: row.get(14)?,
-            body_text: row.get(15)?,
-            body_html: row.get(16)?,
-            is_read: row.get(17)?,
-            is_flagged: row.get(18)?,
-            is_draft: row.get(19)?,
-            is_answered: row.get(20)?,
-            has_attachments: row.get(21)?,
-            attachment_count: row.get(22)?,
-            size_bytes: row.get(23)?,
-            thread_id: row.get(24)?,
-            created_at: row.get(25)?,
-            updated_at: row.get(26)?,
-        })
-    })?;
-
-    Ok(email)
+        Ok(email)
+    })
+    .await?
 }
 
 /// List emails with pagination
@@ -198,99 +205,101 @@ pub async fn list_emails(
     limit: usize,
     offset: usize,
 ) -> Result<Vec<Email>> {
-    let conn_guard = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let query = match (credential_id, folder_id) {
+            (Some(cred), Some(fid)) => {
+                format!(
+                    "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
+                            to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
+                            body_text, body_html, is_read, is_flagged, is_draft, is_answered,
+                            has_attachments, attachment_count, size_bytes, thread_id,
+                            created_at, updated_at
+                     FROM emails WHERE credential_id = {} AND folder_id = {}
+                     ORDER BY date_received DESC LIMIT {} OFFSET {}",
+                    cred, fid, limit, offset
+                )
+            }
+            (Some(cred), None) => {
+                format!(
+                    "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
+                            to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
+                            body_text, body_html, is_read, is_flagged, is_draft, is_answered,
+                            has_attachments, attachment_count, size_bytes, thread_id,
+                            created_at, updated_at
+                     FROM emails WHERE credential_id = {}
+                     ORDER BY date_received DESC LIMIT {} OFFSET {}",
+                    cred, limit, offset
+                )
+            }
+            (None, Some(fid)) => {
+                format!(
+                    "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
+                            to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
+                            body_text, body_html, is_read, is_flagged, is_draft, is_answered,
+                            has_attachments, attachment_count, size_bytes, thread_id,
+                            created_at, updated_at
+                     FROM emails WHERE folder_id = {}
+                     ORDER BY date_received DESC LIMIT {} OFFSET {}",
+                    fid, limit, offset
+                )
+            }
+            (None, None) => {
+                format!(
+                    "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
+                            to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
+                            body_text, body_html, is_read, is_flagged, is_draft, is_answered,
+                            has_attachments, attachment_count, size_bytes, thread_id,
+                            created_at, updated_at
+                     FROM emails ORDER BY date_received DESC
+                     LIMIT {} OFFSET {}",
+                    limit, offset
+                )
+            }
+        };
 
-    let query = match (credential_id, folder_id) {
-        (Some(cred), Some(fid)) => {
-            format!(
-                "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
-                        to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
-                        body_text, body_html, is_read, is_flagged, is_draft, is_answered,
-                        has_attachments, attachment_count, size_bytes, thread_id,
-                        created_at, updated_at
-                 FROM emails WHERE credential_id = {} AND folder_id = {}
-                 ORDER BY date_received DESC LIMIT {} OFFSET {}",
-                cred, fid, limit, offset
-            )
-        }
-        (Some(cred), None) => {
-            format!(
-                "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
-                        to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
-                        body_text, body_html, is_read, is_flagged, is_draft, is_answered,
-                        has_attachments, attachment_count, size_bytes, thread_id,
-                        created_at, updated_at
-                 FROM emails WHERE credential_id = {}
-                 ORDER BY date_received DESC LIMIT {} OFFSET {}",
-                cred, limit, offset
-            )
-        }
-        (None, Some(fid)) => {
-            format!(
-                "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
-                        to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
-                        body_text, body_html, is_read, is_flagged, is_draft, is_answered,
-                        has_attachments, attachment_count, size_bytes, thread_id,
-                        created_at, updated_at
-                 FROM emails WHERE folder_id = {}
-                 ORDER BY date_received DESC LIMIT {} OFFSET {}",
-                fid, limit, offset
-            )
-        }
-        (None, None) => {
-            format!(
-                "SELECT id, download_item_id, credential_id, uid, folder_id, message_id, subject, from_address, from_name,
-                        to_addresses, cc_addresses, bcc_addresses, reply_to, date_sent, date_received,
-                        body_text, body_html, is_read, is_flagged, is_draft, is_answered,
-                        has_attachments, attachment_count, size_bytes, thread_id,
-                        created_at, updated_at
-                 FROM emails ORDER BY date_received DESC
-                 LIMIT {} OFFSET {}",
-                limit, offset
-            )
-        }
-    };
+        let mut stmt = conn.prepare(&query)?;
+        let emails = stmt
+            .query_map([], |row| {
+                let to_json: String = row.get(9)?;
+                let cc_json: String = row.get(10)?;
+                let bcc_json: String = row.get(11)?;
 
-    let mut stmt = conn_guard.prepare(&query)?;
-    let emails = stmt
-        .query_map([], |row| {
-            let to_json: String = row.get(9)?;
-            let cc_json: String = row.get(10)?;
-            let bcc_json: String = row.get(11)?;
+                Ok(Email {
+                    id: row.get(0)?,
+                    download_item_id: row.get(1)?,
+                    credential_id: row.get(2)?,
+                    uid: row.get::<_, i32>(3)? as u32,
+                    folder_id: row.get(4)?,
+                    message_id: row.get(5)?,
+                    subject: row.get(6)?,
+                    from_address: row.get(7)?,
+                    from_name: row.get(8)?,
+                    to_addresses: serde_json::from_str(&to_json).unwrap_or_default(),
+                    cc_addresses: serde_json::from_str(&cc_json).unwrap_or_default(),
+                    bcc_addresses: serde_json::from_str(&bcc_json).unwrap_or_default(),
+                    reply_to: row.get(12)?,
+                    date_sent: row.get(13)?,
+                    date_received: row.get(14)?,
+                    body_text: row.get(15)?,
+                    body_html: row.get(16)?,
+                    is_read: row.get(17)?,
+                    is_flagged: row.get(18)?,
+                    is_draft: row.get(19)?,
+                    is_answered: row.get(20)?,
+                    has_attachments: row.get(21)?,
+                    attachment_count: row.get(22)?,
+                    size_bytes: row.get(23)?,
+                    thread_id: row.get(24)?,
+                    created_at: row.get(25)?,
+                    updated_at: row.get(26)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
 
-            Ok(Email {
-                id: row.get(0)?,
-                download_item_id: row.get(1)?,
-                credential_id: row.get(2)?,
-                uid: row.get::<_, i32>(3)? as u32,
-                folder_id: row.get(4)?,
-                message_id: row.get(5)?,
-                subject: row.get(6)?,
-                from_address: row.get(7)?,
-                from_name: row.get(8)?,
-                to_addresses: serde_json::from_str(&to_json).unwrap_or_default(),
-                cc_addresses: serde_json::from_str(&cc_json).unwrap_or_default(),
-                bcc_addresses: serde_json::from_str(&bcc_json).unwrap_or_default(),
-                reply_to: row.get(12)?,
-                date_sent: row.get(13)?,
-                date_received: row.get(14)?,
-                body_text: row.get(15)?,
-                body_html: row.get(16)?,
-                is_read: row.get(17)?,
-                is_flagged: row.get(18)?,
-                is_draft: row.get(19)?,
-                is_answered: row.get(20)?,
-                has_attachments: row.get(21)?,
-                attachment_count: row.get(22)?,
-                size_bytes: row.get(23)?,
-                thread_id: row.get(24)?,
-                created_at: row.get(25)?,
-                updated_at: row.get(26)?,
-            })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(emails)
+        Ok(emails)
+    })
+    .await?
 }
 
 /// List minimal email fields for scanning
@@ -299,41 +308,43 @@ pub async fn list_email_scan_rows(
     credential_id: Option<i64>,
     max_emails: Option<usize>,
 ) -> Result<Vec<EmailScanRow>> {
-    let conn_guard = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut query = String::from(
+            "SELECT from_address, subject, body_text, body_html FROM emails",
+        );
+        let mut params: Vec<Value> = Vec::new();
 
-    let mut query = String::from(
-        "SELECT from_address, subject, body_text, body_html FROM emails",
-    );
-    let mut params: Vec<Value> = Vec::new();
+        if let Some(cred) = credential_id {
+            query.push_str(" WHERE credential_id = ?");
+            params.push(Value::from(cred));
+        }
 
-    if let Some(cred) = credential_id {
-        query.push_str(" WHERE credential_id = ?");
-        params.push(Value::from(cred));
-    }
+        query.push_str(" ORDER BY date_received DESC");
 
-    query.push_str(" ORDER BY date_received DESC");
+        if let Some(limit) = max_emails {
+            query.push_str(" LIMIT ?");
+            params.push(Value::from(limit as i64));
+        }
 
-    if let Some(limit) = max_emails {
-        query.push_str(" LIMIT ?");
-        params.push(Value::from(limit as i64));
-    }
+        let mut stmt = conn.prepare(&query)?;
+        let rows = stmt.query_map(params_from_iter(params), |row| {
+            Ok(EmailScanRow {
+                from_address: row.get(0)?,
+                subject: row.get(1)?,
+                body_text: row.get(2)?,
+                body_html: row.get(3)?,
+            })
+        })?;
 
-    let mut stmt = conn_guard.prepare(&query)?;
-    let rows = stmt.query_map(params_from_iter(params), |row| {
-        Ok(EmailScanRow {
-            from_address: row.get(0)?,
-            subject: row.get(1)?,
-            body_text: row.get(2)?,
-            body_html: row.get(3)?,
-        })
-    })?;
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row?);
+        }
 
-    let mut results = Vec::new();
-    for row in rows {
-        results.push(row?);
-    }
-
-    Ok(results)
+        Ok(results)
+    })
+    .await?
 }
 
 /// List emails by label with pagination
@@ -343,62 +354,64 @@ pub async fn list_emails_by_label(
     limit: usize,
     offset: usize,
 ) -> Result<Vec<Email>> {
-    let conn_guard = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let query = format!(
+            "SELECT e.id, e.download_item_id, e.credential_id, e.uid, e.folder_id, e.message_id, e.subject, e.from_address, e.from_name,
+                    e.to_addresses, e.cc_addresses, e.bcc_addresses, e.reply_to, e.date_sent, e.date_received,
+                    e.body_text, e.body_html, e.is_read, e.is_flagged, e.is_draft, e.is_answered,
+                    e.has_attachments, e.attachment_count, e.size_bytes, e.thread_id,
+                    e.created_at, e.updated_at
+             FROM emails e
+             INNER JOIN email_label_associations ela ON e.id = ela.email_id
+             WHERE ela.label_id = {}
+             ORDER BY e.date_received DESC
+             LIMIT {} OFFSET {}",
+            label_id, limit, offset
+        );
 
-    let query = format!(
-        "SELECT e.id, e.download_item_id, e.credential_id, e.uid, e.folder_id, e.message_id, e.subject, e.from_address, e.from_name,
-                e.to_addresses, e.cc_addresses, e.bcc_addresses, e.reply_to, e.date_sent, e.date_received,
-                e.body_text, e.body_html, e.is_read, e.is_flagged, e.is_draft, e.is_answered,
-                e.has_attachments, e.attachment_count, e.size_bytes, e.thread_id,
-                e.created_at, e.updated_at
-         FROM emails e
-         INNER JOIN email_label_associations ela ON e.id = ela.email_id
-         WHERE ela.label_id = {}
-         ORDER BY e.date_received DESC
-         LIMIT {} OFFSET {}",
-        label_id, limit, offset
-    );
+        let mut stmt = conn.prepare(&query)?;
+        let emails = stmt
+            .query_map([], |row| {
+                let to_json: String = row.get(9)?;
+                let cc_json: String = row.get(10)?;
+                let bcc_json: String = row.get(11)?;
 
-    let mut stmt = conn_guard.prepare(&query)?;
-    let emails = stmt
-        .query_map([], |row| {
-            let to_json: String = row.get(9)?;
-            let cc_json: String = row.get(10)?;
-            let bcc_json: String = row.get(11)?;
+                Ok(Email {
+                    id: row.get(0)?,
+                    download_item_id: row.get(1)?,
+                    credential_id: row.get(2)?,
+                    uid: row.get::<_, i32>(3)? as u32,
+                    folder_id: row.get(4)?,
+                    message_id: row.get(5)?,
+                    subject: row.get(6)?,
+                    from_address: row.get(7)?,
+                    from_name: row.get(8)?,
+                    to_addresses: serde_json::from_str(&to_json).unwrap_or_default(),
+                    cc_addresses: serde_json::from_str(&cc_json).unwrap_or_default(),
+                    bcc_addresses: serde_json::from_str(&bcc_json).unwrap_or_default(),
+                    reply_to: row.get(12)?,
+                    date_sent: row.get(13)?,
+                    date_received: row.get(14)?,
+                    body_text: row.get(15)?,
+                    body_html: row.get(16)?,
+                    is_read: row.get(17)?,
+                    is_flagged: row.get(18)?,
+                    is_draft: row.get(19)?,
+                    is_answered: row.get(20)?,
+                    has_attachments: row.get(21)?,
+                    attachment_count: row.get(22)?,
+                    size_bytes: row.get(23)?,
+                    thread_id: row.get(24)?,
+                    created_at: row.get(25)?,
+                    updated_at: row.get(26)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
 
-            Ok(Email {
-                id: row.get(0)?,
-                download_item_id: row.get(1)?,
-                credential_id: row.get(2)?,
-                uid: row.get::<_, i32>(3)? as u32,
-                folder_id: row.get(4)?,
-                message_id: row.get(5)?,
-                subject: row.get(6)?,
-                from_address: row.get(7)?,
-                from_name: row.get(8)?,
-                to_addresses: serde_json::from_str(&to_json).unwrap_or_default(),
-                cc_addresses: serde_json::from_str(&cc_json).unwrap_or_default(),
-                bcc_addresses: serde_json::from_str(&bcc_json).unwrap_or_default(),
-                reply_to: row.get(12)?,
-                date_sent: row.get(13)?,
-                date_received: row.get(14)?,
-                body_text: row.get(15)?,
-                body_html: row.get(16)?,
-                is_read: row.get(17)?,
-                is_flagged: row.get(18)?,
-                is_draft: row.get(19)?,
-                is_answered: row.get(20)?,
-                has_attachments: row.get(21)?,
-                attachment_count: row.get(22)?,
-                size_bytes: row.get(23)?,
-                thread_id: row.get(24)?,
-                created_at: row.get(25)?,
-                updated_at: row.get(26)?,
-            })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(emails)
+        Ok(emails)
+    })
+    .await?
 }
 
 /// Insert attachment

--- a/dwata-api/src/database/emails.rs
+++ b/dwata-api/src/database/emails.rs
@@ -2,7 +2,16 @@ use shared_types::email::{Email, EmailAddress, EmailAttachment, AttachmentExtrac
 use crate::database::AsyncDbConnection;
 use anyhow::Result;
 use rusqlite::params_from_iter;
+use rusqlite::types::Value;
 use std::collections::HashSet;
+
+#[derive(Debug, Clone)]
+pub struct EmailScanRow {
+    pub from_address: String,
+    pub subject: Option<String>,
+    pub body_text: Option<String>,
+    pub body_html: Option<String>,
+}
 
 /// Insert email into database
 pub async fn insert_email(
@@ -282,6 +291,49 @@ pub async fn list_emails(
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(emails)
+}
+
+/// List minimal email fields for scanning
+pub async fn list_email_scan_rows(
+    conn: AsyncDbConnection,
+    credential_id: Option<i64>,
+    max_emails: Option<usize>,
+) -> Result<Vec<EmailScanRow>> {
+    let conn_guard = conn.lock().await;
+
+    let mut query = String::from(
+        "SELECT from_address, subject, body_text, body_html FROM emails",
+    );
+    let mut params: Vec<Value> = Vec::new();
+
+    if let Some(cred) = credential_id {
+        query.push_str(" WHERE credential_id = ?");
+        params.push(Value::from(cred));
+    }
+
+    query.push_str(" ORDER BY date_received DESC");
+
+    if let Some(limit) = max_emails {
+        query.push_str(" LIMIT ?");
+        params.push(Value::from(limit as i64));
+    }
+
+    let mut stmt = conn_guard.prepare(&query)?;
+    let rows = stmt.query_map(params_from_iter(params), |row| {
+        Ok(EmailScanRow {
+            from_address: row.get(0)?,
+            subject: row.get(1)?,
+            body_text: row.get(2)?,
+            body_html: row.get(3)?,
+        })
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+
+    Ok(results)
 }
 
 /// List emails by label with pagination

--- a/dwata-api/src/database/financial_patterns.rs
+++ b/dwata-api/src/database/financial_patterns.rs
@@ -12,7 +12,7 @@ pub async fn list_patterns(
     let conn = db_conn.lock().await;
 
     let mut patterns = Vec::new();
-    let columns = "id, name, regex_pattern, description, document_type, status, confidence, \
+    let columns = "id, name, regex_pattern, description, sender_email, document_type, status, confidence, \
         amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, \
         reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at";
 
@@ -62,7 +62,7 @@ pub async fn get_pattern(
 ) -> Result<FinancialPattern> {
     let conn = db_conn.lock().await;
 
-    let columns = "id, name, regex_pattern, description, document_type, status, confidence, \
+    let columns = "id, name, regex_pattern, description, sender_email, document_type, status, confidence, \
         amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, \
         reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at";
 
@@ -89,15 +89,16 @@ pub async fn insert_pattern(
     let conn = db_conn.lock().await;
 
     let id: i64 = conn.query_row(
-        "INSERT INTO financial_patterns (name, regex_pattern, description, document_type, status, confidence,
+        "INSERT INTO financial_patterns (name, regex_pattern, description, sender_email, document_type, status, confidence,
          amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, reference_group,
          is_default, is_active, match_count, last_matched_at, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
          RETURNING id",
         params![
             pattern.name,
             pattern.regex_pattern,
             pattern.description.as_deref(),
+            pattern.sender_email.as_deref(),
             &pattern.document_type,
             &pattern.status,
             pattern.confidence,
@@ -129,15 +130,16 @@ pub async fn update_pattern(
 
     conn.execute(
         "UPDATE financial_patterns
-         SET name = ?1, regex_pattern = ?2, description = ?3, document_type = ?4, status = ?5,
-             confidence = ?6, amount_group = ?7, vendor_group = ?8, source_vendor_group = ?9,
-             destination_vendor_group = ?10, date_group = ?11, reference_group = ?12,
-             is_active = ?13, updated_at = ?14
-         WHERE id = ?15",
+         SET name = ?1, regex_pattern = ?2, description = ?3, sender_email = ?4, document_type = ?5, status = ?6,
+             confidence = ?7, amount_group = ?8, vendor_group = ?9, source_vendor_group = ?10,
+             destination_vendor_group = ?11, date_group = ?12, reference_group = ?13,
+             is_active = ?14, updated_at = ?15
+         WHERE id = ?16",
         params![
             pattern.name,
             pattern.regex_pattern,
             pattern.description.as_deref(),
+            pattern.sender_email.as_deref(),
             &pattern.document_type,
             &pattern.status,
             pattern.confidence,
@@ -199,22 +201,36 @@ pub async fn pattern_name_exists(
 pub async fn pattern_regex_exists(
     db_conn: AsyncDbConnection,
     regex_pattern: &str,
+    sender_email: Option<&str>,
     exclude_id: Option<i64>,
 ) -> Result<bool> {
     let conn = db_conn.lock().await;
 
-    let count: i64 = if let Some(exclude_id) = exclude_id {
-        conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns WHERE regex_pattern = ?1 AND id != ?2",
-            params![regex_pattern, exclude_id],
-            |row| row.get(0)
-        )?
-    } else {
-        conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns WHERE regex_pattern = ?1",
+    let count: i64 = match (sender_email, exclude_id) {
+        (Some(sender), Some(exclude)) => conn.query_row(
+            "SELECT COUNT(*) FROM financial_patterns
+             WHERE regex_pattern = ?1 AND sender_email = ?2 AND id != ?3",
+            params![regex_pattern, sender, exclude],
+            |row| row.get(0),
+        )?,
+        (Some(sender), None) => conn.query_row(
+            "SELECT COUNT(*) FROM financial_patterns
+             WHERE regex_pattern = ?1 AND sender_email = ?2",
+            params![regex_pattern, sender],
+            |row| row.get(0),
+        )?,
+        (None, Some(exclude)) => conn.query_row(
+            "SELECT COUNT(*) FROM financial_patterns
+             WHERE regex_pattern = ?1 AND sender_email IS NULL AND id != ?2",
+            params![regex_pattern, exclude],
+            |row| row.get(0),
+        )?,
+        (None, None) => conn.query_row(
+            "SELECT COUNT(*) FROM financial_patterns
+             WHERE regex_pattern = ?1 AND sender_email IS NULL",
             params![regex_pattern],
-            |row| row.get(0)
-        )?
+            |row| row.get(0),
+        )?,
     };
 
     Ok(count > 0)
@@ -255,20 +271,21 @@ fn map_row_to_pattern(row: &Row) -> rusqlite::Result<FinancialPattern> {
         name: row.get(1)?,
         regex_pattern: row.get(2)?,
         description: row.get(3)?,
-        document_type: row.get(4)?,
-        status: row.get(5)?,
-        confidence: row.get(6)?,
-        amount_group: row.get(7)?,
-        vendor_group: row.get(8)?,
-        source_vendor_group: row.get(9)?,
-        destination_vendor_group: row.get(10)?,
-        date_group: row.get(11)?,
-        reference_group: row.get(12)?,
-        is_default: row.get(13)?,
-        is_active: row.get(14)?,
-        match_count: row.get(15)?,
-        last_matched_at: row.get(16)?,
-        created_at: row.get(17)?,
-        updated_at: row.get(18)?,
+        sender_email: row.get(4)?,
+        document_type: row.get(5)?,
+        status: row.get(6)?,
+        confidence: row.get(7)?,
+        amount_group: row.get(8)?,
+        vendor_group: row.get(9)?,
+        source_vendor_group: row.get(10)?,
+        destination_vendor_group: row.get(11)?,
+        date_group: row.get(12)?,
+        reference_group: row.get(13)?,
+        is_default: row.get(14)?,
+        is_active: row.get(15)?,
+        match_count: row.get(16)?,
+        last_matched_at: row.get(17)?,
+        created_at: row.get(18)?,
+        updated_at: row.get(19)?,
     })
 }

--- a/dwata-api/src/database/financial_patterns.rs
+++ b/dwata-api/src/database/financial_patterns.rs
@@ -2,6 +2,7 @@ use crate::database::AsyncDbConnection;
 use shared_types::FinancialPattern;
 use rusqlite::{params, Row};
 use anyhow::Result;
+use tokio::task;
 
 pub async fn list_patterns(
     db_conn: AsyncDbConnection,
@@ -9,71 +10,71 @@ pub async fn list_patterns(
     is_default: Option<bool>,
     document_type: Option<String>,
 ) -> Result<Vec<FinancialPattern>> {
-    let conn = db_conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        let mut patterns = Vec::new();
+        let columns = "id, name, regex_pattern, description, sender_email, document_type, status, confidence, \
+            amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, \
+            reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at";
 
-    let mut patterns = Vec::new();
-    let columns = "id, name, regex_pattern, description, sender_email, document_type, status, confidence, \
-        amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, \
-        reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at";
+        if active_only || is_default.is_some() || document_type.is_some() {
+            let mut query = format!("SELECT {} FROM financial_patterns WHERE 1=1", columns);
 
-    if active_only || is_default.is_some() || document_type.is_some() {
-        let mut query = format!("SELECT {} FROM financial_patterns WHERE 1=1", columns);
+            if active_only {
+                query.push_str(" AND is_active = true");
+            }
 
-        if active_only {
-            query.push_str(" AND is_active = true");
+            if let Some(default_val) = is_default {
+                query.push_str(&format!(
+                    " AND is_default = {}",
+                    if default_val { "true" } else { "false" }
+                ));
+            }
+
+            if let Some(doc_type) = document_type {
+                query.push_str(&format!(" AND document_type = '{}'", doc_type));
+            }
+
+            query.push_str(" ORDER BY id");
+
+            let mut stmt = conn.prepare(&query)?;
+            let rows = stmt.query_map([], |row| map_row_to_pattern(row))?;
+            for row in rows {
+                patterns.push(row?);
+            }
+        } else {
+            let mut stmt =
+                conn.prepare(&format!("SELECT {} FROM financial_patterns ORDER BY id", columns))?;
+            let rows = stmt.query_map([], |row| map_row_to_pattern(row))?;
+            for row in rows {
+                patterns.push(row?);
+            }
         }
 
-        if let Some(default_val) = is_default {
-            query.push_str(&format!(" AND is_default = {}", if default_val { "true" } else { "false" }));
-        }
-
-        if let Some(doc_type) = document_type {
-            query.push_str(&format!(" AND document_type = '{}'", doc_type));
-        }
-
-        query.push_str(" ORDER BY id");
-
-        let mut stmt = conn.prepare(&query)?;
-
-        let rows = stmt.query_map([], |row| map_row_to_pattern(row))?;
-
-        for row in rows {
-            patterns.push(row?);
-        }
-    } else {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT {} FROM financial_patterns ORDER BY id",
-            columns
-        ))?;
-
-        let rows = stmt.query_map([], |row| map_row_to_pattern(row))?;
-
-        for row in rows {
-            patterns.push(row?);
-        }
-    }
-
-    Ok(patterns)
+        Ok(patterns)
+    })
+    .await?
 }
 
 pub async fn get_pattern(
     db_conn: AsyncDbConnection,
     id: i64,
 ) -> Result<FinancialPattern> {
-    let conn = db_conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        let columns = "id, name, regex_pattern, description, sender_email, document_type, status, confidence, \
+            amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, \
+            reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at";
 
-    let columns = "id, name, regex_pattern, description, sender_email, document_type, status, confidence, \
-        amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, \
-        reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at";
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {} FROM financial_patterns WHERE id = ?1",
+            columns
+        ))?;
 
-    let mut stmt = conn.prepare(&format!(
-        "SELECT {} FROM financial_patterns WHERE id = ?1",
-        columns
-    ))?;
-
-    let pattern = stmt.query_row(params![id], |row| map_row_to_pattern(row))?;
-
-    Ok(pattern)
+        let pattern = stmt.query_row(params![id], |row| map_row_to_pattern(row))?;
+        Ok(pattern)
+    })
+    .await?
 }
 
 pub async fn list_active_patterns(
@@ -86,39 +87,42 @@ pub async fn insert_pattern(
     db_conn: AsyncDbConnection,
     pattern: &FinancialPattern,
 ) -> Result<i64> {
-    let conn = db_conn.lock().await;
+    let pattern = pattern.clone();
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        let id: i64 = conn.query_row(
+            "INSERT INTO financial_patterns (name, regex_pattern, description, sender_email, document_type, status, confidence,
+             amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, reference_group,
+             is_default, is_active, match_count, last_matched_at, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
+             RETURNING id",
+            params![
+                pattern.name,
+                pattern.regex_pattern,
+                pattern.description.as_deref(),
+                pattern.sender_email.as_deref(),
+                &pattern.document_type,
+                &pattern.status,
+                pattern.confidence,
+                pattern.amount_group,
+                pattern.vendor_group,
+                pattern.source_vendor_group,
+                pattern.destination_vendor_group,
+                pattern.date_group,
+                pattern.reference_group,
+                pattern.is_default,
+                pattern.is_active,
+                pattern.match_count,
+                pattern.last_matched_at,
+                pattern.created_at,
+                pattern.updated_at,
+            ],
+            |row| row.get(0),
+        )?;
 
-    let id: i64 = conn.query_row(
-        "INSERT INTO financial_patterns (name, regex_pattern, description, sender_email, document_type, status, confidence,
-         amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group, reference_group,
-         is_default, is_active, match_count, last_matched_at, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
-         RETURNING id",
-        params![
-            pattern.name,
-            pattern.regex_pattern,
-            pattern.description.as_deref(),
-            pattern.sender_email.as_deref(),
-            &pattern.document_type,
-            &pattern.status,
-            pattern.confidence,
-            pattern.amount_group,
-            pattern.vendor_group,
-            pattern.source_vendor_group,
-            pattern.destination_vendor_group,
-            pattern.date_group,
-            pattern.reference_group,
-            pattern.is_default,
-            pattern.is_active,
-            pattern.match_count,
-            pattern.last_matched_at,
-            pattern.created_at,
-            pattern.updated_at,
-        ],
-        |row| row.get(0),
-    )?;
-
-    Ok(id)
+        Ok(id)
+    })
+    .await?
 }
 
 pub async fn update_pattern(
@@ -126,36 +130,39 @@ pub async fn update_pattern(
     id: i64,
     pattern: &FinancialPattern,
 ) -> Result<()> {
-    let conn = db_conn.lock().await;
+    let pattern = pattern.clone();
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        conn.execute(
+            "UPDATE financial_patterns
+             SET name = ?1, regex_pattern = ?2, description = ?3, sender_email = ?4, document_type = ?5, status = ?6,
+                 confidence = ?7, amount_group = ?8, vendor_group = ?9, source_vendor_group = ?10,
+                 destination_vendor_group = ?11, date_group = ?12, reference_group = ?13,
+                 is_active = ?14, updated_at = ?15
+             WHERE id = ?16",
+            params![
+                pattern.name,
+                pattern.regex_pattern,
+                pattern.description.as_deref(),
+                pattern.sender_email.as_deref(),
+                &pattern.document_type,
+                &pattern.status,
+                pattern.confidence,
+                pattern.amount_group,
+                pattern.vendor_group,
+                pattern.source_vendor_group,
+                pattern.destination_vendor_group,
+                pattern.date_group,
+                pattern.reference_group,
+                pattern.is_active,
+                pattern.updated_at,
+                id,
+            ],
+        )?;
 
-    conn.execute(
-        "UPDATE financial_patterns
-         SET name = ?1, regex_pattern = ?2, description = ?3, sender_email = ?4, document_type = ?5, status = ?6,
-             confidence = ?7, amount_group = ?8, vendor_group = ?9, source_vendor_group = ?10,
-             destination_vendor_group = ?11, date_group = ?12, reference_group = ?13,
-             is_active = ?14, updated_at = ?15
-         WHERE id = ?16",
-        params![
-            pattern.name,
-            pattern.regex_pattern,
-            pattern.description.as_deref(),
-            pattern.sender_email.as_deref(),
-            &pattern.document_type,
-            &pattern.status,
-            pattern.confidence,
-            pattern.amount_group,
-            pattern.vendor_group,
-            pattern.source_vendor_group,
-            pattern.destination_vendor_group,
-            pattern.date_group,
-            pattern.reference_group,
-            pattern.is_active,
-            pattern.updated_at,
-            id,
-        ],
-    )?;
-
-    Ok(())
+        Ok(())
+    })
+    .await?
 }
 
 pub async fn toggle_pattern_active(
@@ -163,15 +170,18 @@ pub async fn toggle_pattern_active(
     id: i64,
     is_active: bool,
 ) -> Result<()> {
-    let conn = db_conn.lock().await;
-    let now = chrono::Utc::now().timestamp();
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        let now = chrono::Utc::now().timestamp();
 
-    conn.execute(
-        "UPDATE financial_patterns SET is_active = ?1, updated_at = ?2 WHERE id = ?3",
-        params![is_active, now, id],
-    )?;
+        conn.execute(
+            "UPDATE financial_patterns SET is_active = ?1, updated_at = ?2 WHERE id = ?3",
+            params![is_active, now, id],
+        )?;
 
-    Ok(())
+        Ok(())
+    })
+    .await?
 }
 
 pub async fn pattern_name_exists(
@@ -179,23 +189,26 @@ pub async fn pattern_name_exists(
     name: &str,
     exclude_id: Option<i64>,
 ) -> Result<bool> {
-    let conn = db_conn.lock().await;
+    let name = name.to_string();
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        let count: i64 = if let Some(exclude_id) = exclude_id {
+            conn.query_row(
+                "SELECT COUNT(*) FROM financial_patterns WHERE name = ?1 AND id != ?2",
+                params![name, exclude_id],
+                |row| row.get(0),
+            )?
+        } else {
+            conn.query_row(
+                "SELECT COUNT(*) FROM financial_patterns WHERE name = ?1",
+                params![name],
+                |row| row.get(0),
+            )?
+        };
 
-    let count: i64 = if let Some(exclude_id) = exclude_id {
-        conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns WHERE name = ?1 AND id != ?2",
-            params![name, exclude_id],
-            |row| row.get(0)
-        )?
-    } else {
-        conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns WHERE name = ?1",
-            params![name],
-            |row| row.get(0)
-        )?
-    };
-
-    Ok(count > 0)
+        Ok(count > 0)
+    })
+    .await?
 }
 
 pub async fn pattern_regex_exists(
@@ -204,50 +217,56 @@ pub async fn pattern_regex_exists(
     sender_email: Option<&str>,
     exclude_id: Option<i64>,
 ) -> Result<bool> {
-    let conn = db_conn.lock().await;
+    let regex_pattern = regex_pattern.to_string();
+    let sender_email = sender_email.map(|v| v.to_string());
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        let count: i64 = match (sender_email, exclude_id) {
+            (Some(sender), Some(exclude)) => conn.query_row(
+                "SELECT COUNT(*) FROM financial_patterns
+                 WHERE regex_pattern = ?1 AND sender_email = ?2 AND id != ?3",
+                params![regex_pattern, sender, exclude],
+                |row| row.get(0),
+            )?,
+            (Some(sender), None) => conn.query_row(
+                "SELECT COUNT(*) FROM financial_patterns
+                 WHERE regex_pattern = ?1 AND sender_email = ?2",
+                params![regex_pattern, sender],
+                |row| row.get(0),
+            )?,
+            (None, Some(exclude)) => conn.query_row(
+                "SELECT COUNT(*) FROM financial_patterns
+                 WHERE regex_pattern = ?1 AND sender_email IS NULL AND id != ?2",
+                params![regex_pattern, exclude],
+                |row| row.get(0),
+            )?,
+            (None, None) => conn.query_row(
+                "SELECT COUNT(*) FROM financial_patterns
+                 WHERE regex_pattern = ?1 AND sender_email IS NULL",
+                params![regex_pattern],
+                |row| row.get(0),
+            )?,
+        };
 
-    let count: i64 = match (sender_email, exclude_id) {
-        (Some(sender), Some(exclude)) => conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns
-             WHERE regex_pattern = ?1 AND sender_email = ?2 AND id != ?3",
-            params![regex_pattern, sender, exclude],
-            |row| row.get(0),
-        )?,
-        (Some(sender), None) => conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns
-             WHERE regex_pattern = ?1 AND sender_email = ?2",
-            params![regex_pattern, sender],
-            |row| row.get(0),
-        )?,
-        (None, Some(exclude)) => conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns
-             WHERE regex_pattern = ?1 AND sender_email IS NULL AND id != ?2",
-            params![regex_pattern, exclude],
-            |row| row.get(0),
-        )?,
-        (None, None) => conn.query_row(
-            "SELECT COUNT(*) FROM financial_patterns
-             WHERE regex_pattern = ?1 AND sender_email IS NULL",
-            params![regex_pattern],
-            |row| row.get(0),
-        )?,
-    };
-
-    Ok(count > 0)
+        Ok(count > 0)
+    })
+    .await?
 }
 
 pub async fn increment_match_count(
     db_conn: AsyncDbConnection,
     id: i64,
 ) -> Result<()> {
-    let conn = db_conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        conn.execute(
+            "UPDATE financial_patterns SET match_count = match_count + 1 WHERE id = ?1",
+            params![id],
+        )?;
 
-    conn.execute(
-        "UPDATE financial_patterns SET match_count = match_count + 1 WHERE id = ?1",
-        params![id],
-    )?;
-
-    Ok(())
+        Ok(())
+    })
+    .await?
 }
 
 pub async fn update_last_matched(
@@ -255,14 +274,16 @@ pub async fn update_last_matched(
     id: i64,
     timestamp: i64,
 ) -> Result<()> {
-    let conn = db_conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = db_conn.get_blocking();
+        conn.execute(
+            "UPDATE financial_patterns SET last_matched_at = ?1 WHERE id = ?2",
+            params![timestamp, id],
+        )?;
 
-    conn.execute(
-        "UPDATE financial_patterns SET last_matched_at = ?1 WHERE id = ?2",
-        params![timestamp, id],
-    )?;
-
-    Ok(())
+        Ok(())
+    })
+    .await?
 }
 
 fn map_row_to_pattern(row: &Row) -> rusqlite::Result<FinancialPattern> {

--- a/dwata-api/src/database/folders.rs
+++ b/dwata-api/src/database/folders.rs
@@ -4,79 +4,84 @@ use crate::integrations::real_imap_client::FolderMetadata;
 
 use crate::database::AsyncDbConnection;
 use anyhow::Result;
+use tokio::task;
 
 pub async fn list_folders(conn: AsyncDbConnection, credential_id: i64) -> Result<Vec<EmailFolder>> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT id, credential_id, name, display_name, imap_path, folder_type, parent_folder_id,
+                    uidvalidity, last_synced_uid, oldest_synced_uid, total_messages, unread_messages, is_subscribed,
+                    is_selectable, created_at, updated_at, last_synced_at
+             FROM email_folders
+             WHERE credential_id = ?
+             ORDER BY folder_type, name"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, credential_id, name, display_name, imap_path, folder_type, parent_folder_id,
-                uidvalidity, last_synced_uid, oldest_synced_uid, total_messages, unread_messages, is_subscribed,
-                is_selectable, created_at, updated_at, last_synced_at
-         FROM email_folders
-         WHERE credential_id = ?
-         ORDER BY folder_type, name"
-    )?;
+        let folders = stmt.query_map([credential_id], |row| {
+            Ok(EmailFolder {
+                id: row.get(0)?,
+                credential_id: row.get(1)?,
+                name: row.get(2)?,
+                display_name: row.get(3)?,
+                imap_path: row.get(4)?,
+                folder_type: row.get(5)?,
+                parent_folder_id: row.get(6)?,
+                uidvalidity: row.get::<_, Option<i32>>(7)?.map(|v| v as u32),
+                last_synced_uid: row.get::<_, Option<i32>>(8)?.map(|v| v as u32),
+                oldest_synced_uid: row.get::<_, Option<i32>>(9)?.map(|v| v as u32),
+                total_messages: row.get(10)?,
+                unread_messages: row.get(11)?,
+                is_subscribed: row.get(12)?,
+                is_selectable: row.get(13)?,
+                created_at: row.get(14)?,
+                updated_at: row.get(15)?,
+                last_synced_at: row.get(16)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let folders = stmt.query_map([credential_id], |row| {
-        Ok(EmailFolder {
-            id: row.get(0)?,
-            credential_id: row.get(1)?,
-            name: row.get(2)?,
-            display_name: row.get(3)?,
-            imap_path: row.get(4)?,
-            folder_type: row.get(5)?,
-            parent_folder_id: row.get(6)?,
-            uidvalidity: row.get::<_, Option<i32>>(7)?.map(|v| v as u32),
-            last_synced_uid: row.get::<_, Option<i32>>(8)?.map(|v| v as u32),
-            oldest_synced_uid: row.get::<_, Option<i32>>(9)?.map(|v| v as u32),
-            total_messages: row.get(10)?,
-            unread_messages: row.get(11)?,
-            is_subscribed: row.get(12)?,
-            is_selectable: row.get(13)?,
-            created_at: row.get(14)?,
-            updated_at: row.get(15)?,
-            last_synced_at: row.get(16)?,
-        })
-    })?
-    .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(folders)
+        Ok(folders)
+    })
+    .await?
 }
 
 pub async fn get_folder(conn: AsyncDbConnection, folder_id: i64) -> Result<EmailFolder> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT id, credential_id, name, display_name, imap_path, folder_type, parent_folder_id,
+                    uidvalidity, last_synced_uid, oldest_synced_uid, total_messages, unread_messages, is_subscribed,
+                    is_selectable, created_at, updated_at, last_synced_at
+             FROM email_folders
+             WHERE id = ?"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, credential_id, name, display_name, imap_path, folder_type, parent_folder_id,
-                uidvalidity, last_synced_uid, oldest_synced_uid, total_messages, unread_messages, is_subscribed,
-                is_selectable, created_at, updated_at, last_synced_at
-         FROM email_folders
-         WHERE id = ?"
-    )?;
+        let folder = stmt.query_row([folder_id], |row| {
+            Ok(EmailFolder {
+                id: row.get(0)?,
+                credential_id: row.get(1)?,
+                name: row.get(2)?,
+                display_name: row.get(3)?,
+                imap_path: row.get(4)?,
+                folder_type: row.get(5)?,
+                parent_folder_id: row.get(6)?,
+                uidvalidity: row.get::<_, Option<i32>>(7)?.map(|v| v as u32),
+                last_synced_uid: row.get::<_, Option<i32>>(8)?.map(|v| v as u32),
+                oldest_synced_uid: row.get::<_, Option<i32>>(9)?.map(|v| v as u32),
+                total_messages: row.get(10)?,
+                unread_messages: row.get(11)?,
+                is_subscribed: row.get(12)?,
+                is_selectable: row.get(13)?,
+                created_at: row.get(14)?,
+                updated_at: row.get(15)?,
+                last_synced_at: row.get(16)?,
+            })
+        })?;
 
-    let folder = stmt.query_row([folder_id], |row| {
-        Ok(EmailFolder {
-            id: row.get(0)?,
-            credential_id: row.get(1)?,
-            name: row.get(2)?,
-            display_name: row.get(3)?,
-            imap_path: row.get(4)?,
-            folder_type: row.get(5)?,
-            parent_folder_id: row.get(6)?,
-            uidvalidity: row.get::<_, Option<i32>>(7)?.map(|v| v as u32),
-            last_synced_uid: row.get::<_, Option<i32>>(8)?.map(|v| v as u32),
-            oldest_synced_uid: row.get::<_, Option<i32>>(9)?.map(|v| v as u32),
-            total_messages: row.get(10)?,
-            unread_messages: row.get(11)?,
-            is_subscribed: row.get(12)?,
-            is_selectable: row.get(13)?,
-            created_at: row.get(14)?,
-            updated_at: row.get(15)?,
-            last_synced_at: row.get(16)?,
-        })
-    })?;
-
-    Ok(folder)
+        Ok(folder)
+    })
+    .await?
 }
 
 pub async fn upsert_folder(
@@ -212,41 +217,43 @@ pub async fn list_folders_for_credential(
     conn: AsyncDbConnection,
     credential_id: i64,
 ) -> Result<Vec<EmailFolder>> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT id, credential_id, name, display_name, imap_path, folder_type, parent_folder_id,
+                    uidvalidity, last_synced_uid, oldest_synced_uid, total_messages, unread_messages, is_subscribed,
+                    is_selectable, created_at, updated_at, last_synced_at
+             FROM email_folders
+             WHERE credential_id = ?
+             ORDER BY imap_path",
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, credential_id, name, display_name, imap_path, folder_type, parent_folder_id,
-                uidvalidity, last_synced_uid, oldest_synced_uid, total_messages, unread_messages, is_subscribed,
-                is_selectable, created_at, updated_at, last_synced_at
-         FROM email_folders
-         WHERE credential_id = ?
-         ORDER BY imap_path",
-    )?;
+        let folders = stmt.query_map([credential_id], |row| {
+            Ok(EmailFolder {
+                id: row.get(0)?,
+                credential_id: row.get(1)?,
+                name: row.get(2)?,
+                display_name: row.get(3)?,
+                imap_path: row.get(4)?,
+                folder_type: row.get(5)?,
+                parent_folder_id: row.get(6)?,
+                uidvalidity: row.get::<_, Option<i32>>(7)?.map(|v| v as u32),
+                last_synced_uid: row.get::<_, Option<i32>>(8)?.map(|v| v as u32),
+                oldest_synced_uid: row.get::<_, Option<i32>>(9)?.map(|v| v as u32),
+                total_messages: row.get(10)?,
+                unread_messages: row.get(11)?,
+                is_subscribed: row.get(12)?,
+                is_selectable: row.get(13)?,
+                created_at: row.get(14)?,
+                updated_at: row.get(15)?,
+                last_synced_at: row.get(16)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let folders = stmt.query_map([credential_id], |row| {
-        Ok(EmailFolder {
-            id: row.get(0)?,
-            credential_id: row.get(1)?,
-            name: row.get(2)?,
-            display_name: row.get(3)?,
-            imap_path: row.get(4)?,
-            folder_type: row.get(5)?,
-            parent_folder_id: row.get(6)?,
-            uidvalidity: row.get::<_, Option<i32>>(7)?.map(|v| v as u32),
-            last_synced_uid: row.get::<_, Option<i32>>(8)?.map(|v| v as u32),
-            oldest_synced_uid: row.get::<_, Option<i32>>(9)?.map(|v| v as u32),
-            total_messages: row.get(10)?,
-            unread_messages: row.get(11)?,
-            is_subscribed: row.get(12)?,
-            is_selectable: row.get(13)?,
-            created_at: row.get(14)?,
-            updated_at: row.get(15)?,
-            last_synced_at: row.get(16)?,
-        })
-    })?
-    .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(folders)
+        Ok(folders)
+    })
+    .await?
 }
 
 pub async fn get_folder_by_path(
@@ -254,15 +261,20 @@ pub async fn get_folder_by_path(
     credential_id: i64,
     imap_path: &str,
 ) -> Result<Option<i64>> {
-    let conn = conn.lock().await;
+    let imap_path = imap_path.to_string();
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let folder_id: Option<i64> = conn
+            .query_row(
+                "SELECT id FROM email_folders WHERE credential_id = ? AND imap_path = ?",
+                params![credential_id, imap_path],
+                |row| row.get(0),
+            )
+            .ok();
 
-    let folder_id: Option<i64> = conn.query_row(
-        "SELECT id FROM email_folders WHERE credential_id = ? AND imap_path = ?",
-        params![credential_id, imap_path],
-        |row| row.get(0)
-    ).ok();
-
-    Ok(folder_id)
+        Ok(folder_id)
+    })
+    .await?
 }
 
 pub async fn sync_folders_from_imap(

--- a/dwata-api/src/database/labels.rs
+++ b/dwata-api/src/database/labels.rs
@@ -3,59 +3,64 @@ use shared_types::EmailLabel;
 
 use crate::database::AsyncDbConnection;
 use anyhow::Result;
+use tokio::task;
 
 pub async fn list_labels(conn: AsyncDbConnection, credential_id: i64) -> Result<Vec<EmailLabel>> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT id, credential_id, name, display_name, label_type, color, message_count, created_at, updated_at
+             FROM email_labels
+             WHERE credential_id = ?
+             ORDER BY label_type, name"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, credential_id, name, display_name, label_type, color, message_count, created_at, updated_at
-         FROM email_labels
-         WHERE credential_id = ?
-         ORDER BY label_type, name"
-    )?;
+        let labels = stmt.query_map([credential_id], |row| {
+            Ok(EmailLabel {
+                id: row.get(0)?,
+                credential_id: row.get(1)?,
+                name: row.get(2)?,
+                display_name: row.get(3)?,
+                label_type: row.get(4)?,
+                color: row.get(5)?,
+                message_count: row.get(6)?,
+                created_at: row.get(7)?,
+                updated_at: row.get(8)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let labels = stmt.query_map([credential_id], |row| {
-        Ok(EmailLabel {
-            id: row.get(0)?,
-            credential_id: row.get(1)?,
-            name: row.get(2)?,
-            display_name: row.get(3)?,
-            label_type: row.get(4)?,
-            color: row.get(5)?,
-            message_count: row.get(6)?,
-            created_at: row.get(7)?,
-            updated_at: row.get(8)?,
-        })
-    })?
-    .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(labels)
+        Ok(labels)
+    })
+    .await?
 }
 
 pub async fn get_label(conn: AsyncDbConnection, label_id: i64) -> Result<EmailLabel> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT id, credential_id, name, display_name, label_type, color, message_count, created_at, updated_at
+             FROM email_labels
+             WHERE id = ?"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, credential_id, name, display_name, label_type, color, message_count, created_at, updated_at
-         FROM email_labels
-         WHERE id = ?"
-    )?;
+        let label = stmt.query_row([label_id], |row| {
+            Ok(EmailLabel {
+                id: row.get(0)?,
+                credential_id: row.get(1)?,
+                name: row.get(2)?,
+                display_name: row.get(3)?,
+                label_type: row.get(4)?,
+                color: row.get(5)?,
+                message_count: row.get(6)?,
+                created_at: row.get(7)?,
+                updated_at: row.get(8)?,
+            })
+        })?;
 
-    let label = stmt.query_row([label_id], |row| {
-        Ok(EmailLabel {
-            id: row.get(0)?,
-            credential_id: row.get(1)?,
-            name: row.get(2)?,
-            display_name: row.get(3)?,
-            label_type: row.get(4)?,
-            color: row.get(5)?,
-            message_count: row.get(6)?,
-            created_at: row.get(7)?,
-            updated_at: row.get(8)?,
-        })
-    })?;
-
-    Ok(label)
+        Ok(label)
+    })
+    .await?
 }
 
 pub async fn upsert_label(
@@ -118,32 +123,34 @@ pub async fn remove_label_from_email(conn: AsyncDbConnection, email_id: i64, lab
 }
 
 pub async fn get_labels_for_email(conn: AsyncDbConnection, email_id: i64) -> Result<Vec<EmailLabel>> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT l.id, l.credential_id, l.name, l.display_name, l.label_type, l.color, l.message_count, l.created_at, l.updated_at
+             FROM email_labels l
+             INNER JOIN email_label_associations ela ON l.id = ela.label_id
+             WHERE ela.email_id = ?
+             ORDER BY l.name"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT l.id, l.credential_id, l.name, l.display_name, l.label_type, l.color, l.message_count, l.created_at, l.updated_at
-         FROM email_labels l
-         INNER JOIN email_label_associations ela ON l.id = ela.label_id
-         WHERE ela.email_id = ?
-         ORDER BY l.name"
-    )?;
+        let labels = stmt.query_map([email_id], |row| {
+            Ok(EmailLabel {
+                id: row.get(0)?,
+                credential_id: row.get(1)?,
+                name: row.get(2)?,
+                display_name: row.get(3)?,
+                label_type: row.get(4)?,
+                color: row.get(5)?,
+                message_count: row.get(6)?,
+                created_at: row.get(7)?,
+                updated_at: row.get(8)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let labels = stmt.query_map([email_id], |row| {
-        Ok(EmailLabel {
-            id: row.get(0)?,
-            credential_id: row.get(1)?,
-            name: row.get(2)?,
-            display_name: row.get(3)?,
-            label_type: row.get(4)?,
-            color: row.get(5)?,
-            message_count: row.get(6)?,
-            created_at: row.get(7)?,
-            updated_at: row.get(8)?,
-        })
-    })?
-    .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(labels)
+        Ok(labels)
+    })
+    .await?
 }
 
 pub async fn get_emails_for_label(
@@ -152,20 +159,22 @@ pub async fn get_emails_for_label(
     limit: usize,
     offset: usize,
 ) -> Result<Vec<i64>> {
-    let conn = conn.lock().await;
+    task::spawn_blocking(move || {
+        let conn = conn.get_blocking();
+        let mut stmt = conn.prepare(
+            "SELECT email_id
+             FROM email_label_associations
+             WHERE label_id = ?
+             ORDER BY created_at DESC
+             LIMIT ? OFFSET ?"
+        )?;
 
-    let mut stmt = conn.prepare(
-        "SELECT email_id
-         FROM email_label_associations
-         WHERE label_id = ?
-         ORDER BY created_at DESC
-         LIMIT ? OFFSET ?"
-    )?;
+        let email_ids = stmt.query_map([label_id, limit as i64, offset as i64], |row| {
+            Ok(row.get::<_, i64>(0)?)
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let email_ids = stmt.query_map([label_id, limit as i64, offset as i64], |row| {
-        Ok(row.get::<_, i64>(0)?)
-    })?
-    .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(email_ids)
+        Ok(email_ids)
+    })
+    .await?
 }

--- a/dwata-api/src/database/migrations.rs
+++ b/dwata-api/src/database/migrations.rs
@@ -12,6 +12,105 @@ fn table_has_column(conn: &Connection, table: &str, column: &str) -> anyhow::Res
     Ok(false)
 }
 
+fn table_sql_contains(conn: &Connection, table: &str, needle: &str) -> anyhow::Result<bool> {
+    let sql: Option<String> = conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        [table],
+        |row| row.get(0),
+    )?;
+    Ok(sql.map(|s| s.contains(needle)).unwrap_or(false))
+}
+
+fn rebuild_financial_patterns_table(conn: &mut Connection) -> anyhow::Result<()> {
+    let tx = conn.transaction()?;
+
+    tx.execute(
+        "ALTER TABLE financial_patterns RENAME TO financial_patterns_old",
+        [],
+    )?;
+
+    tx.execute(
+        "CREATE TABLE financial_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+            -- Pattern identity
+            name VARCHAR NOT NULL,
+            regex_pattern VARCHAR NOT NULL,
+            description VARCHAR,
+            sender_email VARCHAR,
+
+            -- Pattern metadata
+            document_type VARCHAR NOT NULL,
+            status VARCHAR NOT NULL,
+            confidence FLOAT NOT NULL,
+
+            -- Capture group indices (which regex group contains each field)
+            amount_group INTEGER NOT NULL,
+            vendor_group INTEGER,
+            source_vendor_group INTEGER,
+            destination_vendor_group INTEGER,
+            date_group INTEGER,
+            reference_group INTEGER,
+
+            -- Management flags
+            is_default BOOLEAN DEFAULT false,
+            is_active BOOLEAN DEFAULT true,
+
+            -- Usage statistics
+            match_count INTEGER DEFAULT 0,
+            last_matched_at BIGINT,
+
+            -- Timestamps
+            created_at BIGINT NOT NULL,
+            updated_at BIGINT NOT NULL,
+
+            -- Uniqueness constraints
+            UNIQUE(name)
+        )",
+        [],
+    )?;
+
+    tx.execute(
+        "INSERT INTO financial_patterns (
+            id, name, regex_pattern, description, sender_email, document_type, status, confidence,
+            amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group,
+            reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at
+        )
+        SELECT
+            id, name, regex_pattern, description, sender_email, document_type, status, confidence,
+            amount_group, vendor_group, source_vendor_group, destination_vendor_group, date_group,
+            reference_group, is_default, is_active, match_count, last_matched_at, created_at, updated_at
+        FROM financial_patterns_old",
+        [],
+    )?;
+
+    tx.execute("DROP TABLE financial_patterns_old", [])?;
+
+    tx.execute(
+        "CREATE INDEX IF NOT EXISTS idx_financial_patterns_active ON financial_patterns(is_active)",
+        [],
+    )?;
+    tx.execute(
+        "CREATE INDEX IF NOT EXISTS idx_financial_patterns_type ON financial_patterns(document_type)",
+        [],
+    )?;
+    tx.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_financial_patterns_regex_sender_unique
+         ON financial_patterns(regex_pattern, sender_email)
+         WHERE sender_email IS NOT NULL",
+        [],
+    )?;
+    tx.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_financial_patterns_regex_unique_null_sender
+         ON financial_patterns(regex_pattern)
+         WHERE sender_email IS NULL",
+        [],
+    )?;
+
+    tx.commit()?;
+    Ok(())
+}
+
 fn migrate_financial_schema(conn: &Connection) -> anyhow::Result<()> {
     let has_data_source_type =
         table_has_column(conn, "financial_transactions", "data_source_type")?;
@@ -30,7 +129,7 @@ fn migrate_financial_schema(conn: &Connection) -> anyhow::Result<()> {
 
 /// Run all database migrations
 #[allow(dead_code)]
-pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
+pub fn run_migrations(conn: &mut Connection) -> anyhow::Result<()> {
     // Create agent_sessions table
     conn.execute(
         "CREATE TABLE IF NOT EXISTS agent_sessions (
@@ -693,6 +792,8 @@ pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
             name VARCHAR NOT NULL,
             regex_pattern VARCHAR NOT NULL,
             description VARCHAR,
+            sender_email VARCHAR,
+            sender_email VARCHAR,
 
             -- Pattern metadata
             document_type VARCHAR NOT NULL,
@@ -720,19 +821,8 @@ pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
             updated_at BIGINT NOT NULL,
 
             -- Uniqueness constraints
-            UNIQUE(name),
-            UNIQUE(regex_pattern)
+            UNIQUE(name)
         )",
-        [],
-    )?;
-
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_financial_patterns_active ON financial_patterns(is_active)",
-        [],
-    )?;
-
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_financial_patterns_type ON financial_patterns(document_type)",
         [],
     )?;
 
@@ -756,6 +846,41 @@ pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
+
+    if !table_has_column(conn, "financial_patterns", "sender_email")? {
+        conn.execute(
+            "ALTER TABLE financial_patterns ADD COLUMN sender_email VARCHAR",
+            [],
+        )?;
+    }
+
+    if table_sql_contains(conn, "financial_patterns", "UNIQUE(regex_pattern)")? {
+        rebuild_financial_patterns_table(conn)?;
+    }
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_financial_patterns_active ON financial_patterns(is_active)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_financial_patterns_type ON financial_patterns(document_type)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_financial_patterns_regex_sender_unique
+         ON financial_patterns(regex_pattern, sender_email)
+         WHERE sender_email IS NOT NULL",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_financial_patterns_regex_unique_null_sender
+         ON financial_patterns(regex_pattern)
+         WHERE sender_email IS NULL",
+        [],
+    )?;
 
     // Create email_folders table
     conn.execute(
@@ -841,141 +966,6 @@ pub fn run_migrations(conn: &Connection) -> anyhow::Result<()> {
 
     conn.execute("CREATE INDEX IF NOT EXISTS idx_email_label_assoc_email ON email_label_associations(email_id)", [])?;
     conn.execute("CREATE INDEX IF NOT EXISTS idx_email_label_assoc_label ON email_label_associations(label_id)", [])?;
-
-    // Seed default financial patterns
-    conn.execute(
-        "INSERT INTO financial_patterns
-            (name, regex_pattern, description, document_type, status, confidence,
-             amount_group, vendor_group, source_vendor_group, destination_vendor_group,
-             date_group, reference_group, is_default, is_active,
-             match_count, created_at, updated_at)
-        VALUES
-            -- Payment Confirmation Patterns (5)
-            ('payment_to_vendor',
-             '(?i)payment of \\$?([\\d,]+\\.?\\d{0,2}) to ([A-Za-z\\s]+)',
-             'Matches: \"payment of $150.00 to Comcast\"',
-             'payment-confirmation', 'paid', 0.90,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('paid_amount_to_vendor',
-             '(?i)paid \\$?([\\d,]+\\.?\\d{0,2}) to ([A-Za-z\\s]+)',
-             'Matches: \"paid $99 to Adobe\"',
-             'payment-confirmation', 'paid', 0.88,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('your_payment_to_vendor',
-             '(?i)your \\$?([\\d,]+\\.?\\d{0,2}) payment to ([A-Za-z\\s]+)',
-             'Matches: \"Your $50.00 payment to Netflix\"',
-             'payment-confirmation', 'paid', 0.87,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('successfully_paid_to_vendor',
-             '(?i)successfully paid \\$?([\\d,]+\\.?\\d{0,2}) to ([A-Za-z\\s]+)',
-             'Matches: \"successfully paid $1,200.00 to Chase\"',
-             'payment-confirmation', 'paid', 0.92,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('payment_processed_to_vendor',
-             '(?i)payment processed:? \\$?([\\d,]+\\.?\\d{0,2}) to ([A-Za-z\\s]+)',
-             'Matches: \"payment processed: $45.99 to Spotify\"',
-             'payment-confirmation', 'paid', 0.91,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            -- Bill/Invoice Due Patterns (4)
-            ('bill_due_explicit',
-             '(?i)bill (?:of|for) \\$?([\\d,]+\\.?\\d{0,2}) (?:is )?due (?:on )?([A-Za-z]+ \\d{1,2})',
-             'Matches: \"bill of $99.99 is due on Feb 10\"',
-             'bill', 'pending', 0.88,
-             1, NULL, NULL, NULL, 2, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('invoice_due_date',
-             '(?i)invoice for \\$?([\\d,]+\\.?\\d{0,2}) due ([A-Za-z]+ \\d{1,2})',
-             'Matches: \"invoice for $3,500 due January 25\"',
-             'invoice', 'pending', 0.89,
-             1, NULL, NULL, NULL, 2, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('vendor_bill_due',
-             '(?i)(?:your )?([A-Za-z]+) bill (?:\\(?\\$?([\\d,]+\\.?\\d{0,2})\\)?) is due ([A-Za-z]+ \\d{1,2})',
-             'Matches: \"Your Adobe bill ($99) is due Feb 10\"',
-             'bill', 'pending', 0.87,
-             2, NULL, NULL, 1, 3, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('due_amount_by_date',
-             '(?i)due:? \\$?([\\d,]+\\.?\\d{0,2}) by (\\d{2}/\\d{2}/\\d{4})',
-             'Matches: \"due: $150.00 by 02/05/2026\"',
-             'bill', 'pending', 0.86,
-             1, NULL, NULL, NULL, 2, NULL,
-             true, true,
-             0, 0, 0),
-
-            -- Payment Received Patterns (3)
-            ('received_payment_from',
-             '(?i)received (?:a payment of )?\\$?([\\d,]+\\.?\\d{0,2}) from ([A-Za-z\\s]+)',
-             'Matches: \"received $3,500.00 from Acme Corp\"',
-             'invoice', 'paid', 0.92,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('payment_of_from',
-             '(?i)payment of \\$?([\\d,]+\\.?\\d{0,2}) from ([A-Za-z\\s]+)',
-             'Matches: \"payment of $2,000 from TechStart Inc\"',
-             'invoice', 'paid', 0.90,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('you_received_payment',
-             '(?i)you received (?:a payment:? )?\\$?([\\d,]+\\.?\\d{0,2}) from ([A-Za-z\\s]+)',
-             'Matches: \"You received a payment: $1,500 from Client Name\"',
-             'invoice', 'paid', 0.91,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            -- Overdue/Late Patterns (3)
-            ('payment_overdue',
-             '(?i)payment of \\$?([\\d,]+\\.?\\d{0,2}) (?:is |to ([A-Za-z\\s]+) )?(?:is )?overdue',
-             'Matches: \"payment of $1,200 is overdue\" or \"payment of $1,200 to Chase is overdue\"',
-             'bill', 'overdue', 0.93,
-             1, NULL, NULL, 2, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('amount_past_due',
-             '(?i)\\$?([\\d,]+\\.?\\d{0,2}) payment past due',
-             'Matches: \"$450.00 payment past due\"',
-             'bill', 'overdue', 0.91,
-             1, NULL, NULL, NULL, NULL, NULL,
-             true, true,
-             0, 0, 0),
-
-            ('overdue_bill_days',
-             '(?i)overdue bill:? \\$?([\\d,]+\\.?\\d{0,2})(?: \\((\\d+) days? late\\))?',
-             'Matches: \"overdue bill: $99 (3 days late)\"',
-             'bill', 'overdue', 0.90,
-             1, NULL, NULL, NULL, NULL, NULL,
-             true, true,
-             0, 0, 0)
-        ON CONFLICT (regex_pattern) DO NOTHING",
-        [],
-    )?;
 
     tracing::info!("Database migrations completed successfully");
 

--- a/dwata-api/src/database/mod.rs
+++ b/dwata-api/src/database/mod.rs
@@ -67,7 +67,7 @@ impl Database {
         // Run migrations on sync connection before opening async connection
         {
             let mut conn = sync_mutex.lock().unwrap();
-            migrations::run_migrations(&conn)?;
+        migrations::run_migrations(&mut conn)?;
             migrations::migrate_folders_and_labels(&mut *conn)?;
         }
 

--- a/dwata-api/src/database/mod.rs
+++ b/dwata-api/src/database/mod.rs
@@ -44,6 +44,12 @@ impl AsyncDbConnection {
             .get()
             .expect("Failed to get DB connection from pool")
     }
+
+    pub fn get_blocking(&self) -> PooledConnection<SqliteConnectionManager> {
+        self.pool
+            .get()
+            .expect("Failed to get DB connection from pool")
+    }
 }
 
 pub struct Database {
@@ -74,7 +80,7 @@ impl Database {
         // Now open pooled connections - they will see the migrated schema
         let manager = SqliteConnectionManager::file(db_path).with_init(|conn| {
             conn.busy_timeout(Duration::from_secs(5))?;
-            conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+            conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;")?;
             Ok(())
         });
 

--- a/dwata-api/src/handlers/financial.rs
+++ b/dwata-api/src/handlers/financial.rs
@@ -150,6 +150,7 @@ pub struct CreatePatternRequest {
     pub name: String,
     pub regex_pattern: String,
     pub description: Option<String>,
+    pub sender_email: Option<String>,
     pub document_type: String,
     pub status: String,
     pub confidence: f32,
@@ -196,6 +197,7 @@ pub async fn create_pattern(
     let regex_exists = patterns_db::pattern_regex_exists(
         db.async_connection.clone(),
         &request.regex_pattern,
+        request.sender_email.as_deref(),
         None,
     )
     .await
@@ -212,6 +214,7 @@ pub async fn create_pattern(
         name: request.name.clone(),
         regex_pattern: request.regex_pattern.clone(),
         description: request.description.clone(),
+        sender_email: request.sender_email.clone(),
         document_type: request.document_type.clone(),
         status: request.status.clone(),
         confidence: request.confidence,
@@ -248,6 +251,7 @@ pub struct UpdatePatternRequest {
     pub name: Option<String>,
     pub regex_pattern: Option<String>,
     pub description: Option<String>,
+    pub sender_email: Option<String>,
     pub document_type: Option<String>,
     pub status: Option<String>,
     pub confidence: Option<f32>,
@@ -284,6 +288,7 @@ pub async fn update_pattern(
         name: request.name.clone().unwrap_or(existing.name),
         regex_pattern: request.regex_pattern.clone().unwrap_or(existing.regex_pattern),
         description: request.description.clone().or(existing.description),
+        sender_email: request.sender_email.clone().or(existing.sender_email),
         document_type: request.document_type.clone().unwrap_or(existing.document_type),
         status: request.status.clone().unwrap_or(existing.status),
         confidence: request.confidence.unwrap_or(existing.confidence),
@@ -368,6 +373,8 @@ const DEFAULT_FINANCIAL_REGEXES: &[&str] = &[
     r"(?i)\b(refund|chargeback)\b",
 ];
 
+const TEMPLATE_SIMILARITY_THRESHOLD: f32 = 0.45;
+
 pub async fn scan_financial_emails(
     db: web::Data<Arc<Database>>,
     request: web::Json<FinancialEmailScanRequest>,
@@ -403,7 +410,7 @@ pub async fn scan_financial_emails(
     .map_err(|e| actix_web::error::ErrorInternalServerError(e.to_string()))?;
 
     let mut sender_counts: HashMap<String, i64> = HashMap::new();
-    let mut total_matched = 0i64;
+    let mut sender_tokens: HashMap<String, Vec<Vec<String>>> = HashMap::new();
 
     for row in rows.iter() {
         let mut content = String::new();
@@ -431,10 +438,35 @@ pub async fn scan_financial_emails(
         }
 
         if matched {
-            total_matched += 1;
-            *sender_counts.entry(row.from_address.clone()).or_insert(0) += 1;
+            let sender = row.from_address.clone();
+            *sender_counts.entry(sender.clone()).or_insert(0) += 1;
+            sender_tokens
+                .entry(sender)
+                .or_insert_with(Vec::new)
+                .push(tokenize_words(&content));
         }
     }
+
+    // If a sender's matched emails differ too much at a word level, they are likely not
+    // templated transaction emails. We drop them for now (may miss manual emails).
+    let mut total_matched = 0i64;
+    sender_counts.retain(|sender, count| {
+        let keep = sender_tokens
+            .get(sender)
+            .and_then(|tokens| {
+                if tokens.len() < 2 {
+                    return Some(true);
+                }
+                let avg = average_normalized_distance(tokens);
+                Some(avg <= TEMPLATE_SIMILARITY_THRESHOLD)
+            })
+            .unwrap_or(true);
+
+        if keep {
+            total_matched += *count;
+        }
+        keep
+    });
 
     let mut senders: Vec<FinancialEmailScanSender> = sender_counts
         .into_iter()
@@ -461,6 +493,63 @@ pub async fn scan_financial_emails(
         total_matched_emails: total_matched,
         senders,
     }))
+}
+
+fn tokenize_words(text: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            words.push(current);
+            current = String::new();
+        }
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+fn average_normalized_distance(samples: &[Vec<String>]) -> f32 {
+    let baseline = &samples[0];
+    let mut total = 0f32;
+    let mut count = 0f32;
+    for candidate in samples.iter().skip(1) {
+        total += normalized_word_distance(baseline, candidate);
+        count += 1.0;
+    }
+    if count == 0.0 {
+        0.0
+    } else {
+        total / count
+    }
+}
+
+fn normalized_word_distance(a: &[String], b: &[String]) -> f32 {
+    let dist = word_edit_distance(a, b) as f32;
+    let denom = a.len().max(b.len()).max(1) as f32;
+    dist / denom
+}
+
+fn word_edit_distance(a: &[String], b: &[String]) -> usize {
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+
+    for (i, aw) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, bw) in b.iter().enumerate() {
+            let cost = if aw == bw { 0 } else { 1 };
+            let insert = curr[j] + 1;
+            let delete = prev[j + 1] + 1;
+            let replace = prev[j] + cost;
+            curr[j + 1] = insert.min(delete).min(replace);
+        }
+        prev.copy_from_slice(&curr);
+    }
+
+    prev[b.len()]
 }
 
 #[derive(Deserialize)]

--- a/dwata-api/src/handlers/financial.rs
+++ b/dwata-api/src/handlers/financial.rs
@@ -8,11 +8,14 @@ use crate::database::{
 use crate::database::Database;
 use crate::helpers::pattern_validator;
 use crate::jobs::financial_extraction_manager::FinancialExtractionManager;
+use regex::Regex;
 use serde::Deserialize;
 use shared_types::{
+    FinancialEmailScanRequest, FinancialEmailScanResponse, FinancialEmailScanSender,
     FinancialExtractionAttemptsResponse, FinancialExtractionSummary, FinancialPattern,
 };
 use std::sync::Arc;
+use std::collections::HashMap;
 use tracing::info;
 
 pub async fn list_transactions(
@@ -329,6 +332,135 @@ pub async fn update_pattern(
         "pattern": updated_pattern,
         "message": "Pattern updated successfully"
     })))
+}
+
+const DEFAULT_FINANCIAL_KEYWORDS: &[&str] = &[
+    "payment",
+    "paid",
+    "invoice",
+    "receipt",
+    "transaction",
+    "transfer",
+    "deposit",
+    "withdrawal",
+    "charge",
+    "charged",
+    "refund",
+    "statement",
+    "balance",
+    "credit",
+    "debit",
+];
+
+const DEFAULT_FINANCIAL_REGEXES: &[&str] = &[
+    r"(?i)\btransaction\s*(id|#|no\.?|number)\b",
+    r"(?i)\bconfirmation\s*(id|#|no\.?|number)\b",
+    r"(?i)\bpayment\s*(id|#|no\.?|number)\b",
+    r"(?i)\binvoice\s*(id|#|no\.?|number)\b",
+    r"(?i)\border\s*(id|#|no\.?|number)\b",
+    r"(?i)\b(auth|authorization)\s*(code|id|#|no\.?)\b",
+    r"(?i)\b(ref|reference)\s*(id|#|no\.?|number)\b",
+    r"(?i)\b(ach|sepa|swift|wire)\b",
+    r"(?i)\b(transfer|deposit|withdrawal)\b",
+    r"(?i)\b(card)\s*(ending|ends?)\s*in\s*\d{2,4}\b",
+    r"(?i)\b(last\s*4|ending)\s*\d{2,4}\b",
+    r"(?i)\b(balance|amount\s*due|amount\s*paid|total\s*paid)\b",
+    r"(?i)\b(refund|chargeback)\b",
+];
+
+pub async fn scan_financial_emails(
+    db: web::Data<Arc<Database>>,
+    request: web::Json<FinancialEmailScanRequest>,
+) -> ActixResult<HttpResponse> {
+    let keywords: Vec<String> = DEFAULT_FINANCIAL_KEYWORDS
+        .iter()
+        .map(|k| k.to_string())
+        .collect();
+    let keywords_lower: Vec<String> = keywords
+        .iter()
+        .map(|k| k.to_lowercase())
+        .collect();
+
+    let mut regexes = Vec::new();
+    for pattern in DEFAULT_FINANCIAL_REGEXES {
+        match Regex::new(pattern) {
+            Ok(re) => regexes.push(re),
+            Err(e) => {
+                return Err(actix_web::error::ErrorBadRequest(format!(
+                    "Invalid regex pattern '{}': {}",
+                    pattern, e
+                )));
+            }
+        }
+    }
+
+    let rows = crate::database::emails::list_email_scan_rows(
+        db.async_connection.clone(),
+        request.credential_id,
+        request.max_emails,
+    )
+    .await
+    .map_err(|e| actix_web::error::ErrorInternalServerError(e.to_string()))?;
+
+    let mut sender_counts: HashMap<String, i64> = HashMap::new();
+    let mut total_matched = 0i64;
+
+    for row in rows.iter() {
+        let mut content = String::new();
+        if let Some(subject) = &row.subject {
+            content.push_str(subject);
+            content.push('\n');
+        }
+        if let Some(body_text) = &row.body_text {
+            content.push_str(body_text);
+            content.push('\n');
+        }
+        if let Some(body_html) = &row.body_html {
+            content.push_str(body_html);
+        }
+
+        let mut matched = false;
+
+        if !keywords_lower.is_empty() {
+            let content_lower = content.to_lowercase();
+            matched = keywords_lower.iter().any(|k| content_lower.contains(k));
+        }
+
+        if !matched && !regexes.is_empty() {
+            matched = regexes.iter().any(|re| re.is_match(&content));
+        }
+
+        if matched {
+            total_matched += 1;
+            *sender_counts.entry(row.from_address.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let mut senders: Vec<FinancialEmailScanSender> = sender_counts
+        .into_iter()
+        .map(|(sender_email, matched_count)| FinancialEmailScanSender {
+            sender_email,
+            matched_count,
+        })
+        .collect();
+
+    senders.sort_by(|a, b| {
+        b.matched_count
+            .cmp(&a.matched_count)
+            .then_with(|| a.sender_email.cmp(&b.sender_email))
+    });
+
+    if let Some(max_senders) = request.max_senders {
+        if senders.len() > max_senders {
+            senders.truncate(max_senders);
+        }
+    }
+
+    Ok(HttpResponse::Ok().json(FinancialEmailScanResponse {
+        total_emails_scanned: rows.len() as i64,
+        total_matched_emails: total_matched,
+        senders,
+    }))
 }
 
 #[derive(Deserialize)]

--- a/dwata-api/src/jobs/download_manager.rs
+++ b/dwata-api/src/jobs/download_manager.rs
@@ -390,199 +390,240 @@ impl DownloadManager {
                     return Ok(());
                 }
 
-                let mut imap_client = match auth_info.as_ref() {
-                    AuthInfo::OAuth(token) => RealImapClient::connect_with_oauth(&server, port, &username, token)?,
-                    AuthInfo::Password(password) => RealImapClient::connect_with_password(&server, port, &username, password)?,
-                };
-
-                tracing::info!("Processing folder: {}", db_folder.imap_path);
-
-                let resume_uid = db_folder.last_synced_uid;
-                let uids = match job.job_type {
-                    JobType::RecentSync => {
-                        // Download new emails (UID > last_synced_uid)
-                        match imap_client.search_emails(
-                            &db_folder.imap_path,
-                            resume_uid,
-                            None,
-                            max_age_months,
-                            Some(fetch_batch_size),
-                        ) {
-                            Ok(uids) => uids,
-                            Err(e) => {
-                                tracing::warn!("Failed to search emails in folder '{}': {}. Skipping.", db_folder.imap_path, e);
-                                return Ok(());
-                            }
-                        }
-                    }
-                    JobType::HistoricalBackfill => {
-                        // Download historical emails using a persistent oldest UID cursor per folder.
-                        let mut oldest_uid = db_folder.oldest_synced_uid;
-                        if oldest_uid.is_none() {
-                            oldest_uid = emails::get_oldest_uid_for_folder(
-                                db_conn.clone(),
-                                job.credential_id,
-                                db_folder.id,
-                            ).await?;
-                            if let Some(uid) = oldest_uid {
-                                // Seed backfill cursor from existing data.
-                                folders::update_folder_backfill_state(
-                                    db_conn.clone(),
-                                    db_folder.id,
-                                    uid,
-                                ).await?;
-                            }
-                        }
-
-                        let before_uid = match oldest_uid {
-                            Some(uid) if uid > 1 => Some(uid),
-                            _ => None,
-                        };
-
-                        if before_uid.is_none() {
-                            tracing::debug!("No older UIDs to backfill for {}", db_folder.imap_path);
-                            return Ok(());
-                        }
-
-                        let all_uids = match imap_client.search_emails(
-                            &db_folder.imap_path,
-                            None,
-                            before_uid,
-                            None,
-                            None,
-                        ) {
-                            Ok(uids) => uids,
-                            Err(e) => {
-                                tracing::warn!("Failed to search emails in folder '{}': {}. Skipping.", db_folder.imap_path, e);
-                                return Ok(());
-                            }
-                        };
-
-                        let mut historical_uids = all_uids;
-                        historical_uids.sort_unstable_by(|a, b| b.cmp(a));
-                        historical_uids.truncate(fetch_batch_size);
-                        historical_uids
-                    }
-                };
-
-                let uids = emails::filter_new_uids(
-                    db_conn.clone(),
-                    job.credential_id,
-                    db_folder.id,
-                    &uids,
-                ).await?;
-
-                tracing::info!("Found {} new emails to download in {}", uids.len(), db_folder.imap_path);
-
-                let mut highest_uid = db_folder.last_synced_uid;
-                let mut lowest_uid: Option<u32> = None;
-
-                for uid in uids {
+                let handle = tokio::runtime::Handle::current();
+                let result = tokio::task::spawn_blocking(move || {
                     if shutdown_flag.load(Ordering::SeqCst) {
                         return Ok(());
                     }
 
-                    match imap_client.fetch_email(&db_folder.imap_path, uid) {
-                        Ok(parsed_email) => {
-                            let to_addresses: Vec<EmailAddress> = parsed_email.to_addresses
-                                .iter()
-                                .filter_map(|(addr, name)| {
-                                    addr.as_ref().map(|a| EmailAddress {
-                                        email: a.clone(),
-                                        name: name.clone(),
-                                    })
-                                })
-                                .collect();
+                    let mut imap_client = match auth_info.as_ref() {
+                        AuthInfo::OAuth(token) => {
+                            RealImapClient::connect_with_oauth(&server, port, &username, token)?
+                        }
+                        AuthInfo::Password(password) => {
+                            RealImapClient::connect_with_password(&server, port, &username, password)?
+                        }
+                    };
 
-                            // Use transactional insert to ensure atomicity
-                            match db::insert_email_download_transactional(
-                                db_conn.clone(),
-                                job.id,
-                                job.credential_id,
-                                parsed_email.uid,
-                                db_folder.id,
-                                parsed_email.message_id.as_deref(),
-                                parsed_email.subject.as_deref(),
-                                &parsed_email.from_address.unwrap_or_default(),
-                                parsed_email.from_name.as_deref(),
-                                &to_addresses,
-                                &[],
-                                &[],
-                                parsed_email.reply_to.as_deref(),
-                                parsed_email.date_sent,
-                                parsed_email.date_received,
-                                parsed_email.body_text.as_deref(),
-                                parsed_email.body_html.as_deref(),
-                                parsed_email.is_read,
-                                parsed_email.is_flagged,
-                                parsed_email.is_draft,
-                                parsed_email.is_answered,
-                                parsed_email.has_attachments,
-                                parsed_email.attachment_count,
-                                parsed_email.size_bytes,
-                                &parsed_email.labels,
-                            ).await {
-                                Ok((_download_item_id, email_id)) => {
-                                    tracing::info!("Downloaded and stored email UID {} (id: {}) in transaction", uid, email_id);
-                                    // Track highest UID for updating folder sync state
-                                    highest_uid = Some(highest_uid.map_or(uid, |last| last.max(uid)));
-                                    lowest_uid = Some(lowest_uid.map_or(uid, |last| last.min(uid)));
-                                }
+                    tracing::info!("Processing folder: {}", db_folder.imap_path);
+
+                    let resume_uid = db_folder.last_synced_uid;
+                    let uids = match job.job_type {
+                        JobType::RecentSync => {
+                            match imap_client.search_emails(
+                                &db_folder.imap_path,
+                                resume_uid,
+                                None,
+                                max_age_months,
+                                Some(fetch_batch_size),
+                            ) {
+                                Ok(uids) => uids,
                                 Err(e) => {
-                                    tracing::error!("Failed to store email UID {} in transaction: {}", uid, e);
-                                    // Update failed count
-                                    db::update_job_progress(
-                                        db_conn.clone(),
-                                        job.id,
-                                        None,
-                                        None,
-                                        Some(1),
-                                        None,
-                                        None,
-                                    )
-                                    .await?;
+                                    tracing::warn!(
+                                        "Failed to search emails in folder '{}': {}. Skipping.",
+                                        db_folder.imap_path,
+                                        e
+                                    );
+                                    return Ok(());
                                 }
                             }
                         }
-                        Err(e) => {
-                            tracing::error!("Failed to download email UID {}: {}", uid, e);
+                        JobType::HistoricalBackfill => {
+                            let mut oldest_uid = db_folder.oldest_synced_uid;
+                            if oldest_uid.is_none() {
+                                oldest_uid = handle.block_on(emails::get_oldest_uid_for_folder(
+                                    db_conn.clone(),
+                                    job.credential_id,
+                                    db_folder.id,
+                                ))?;
+                                if let Some(uid) = oldest_uid {
+                                    handle.block_on(folders::update_folder_backfill_state(
+                                        db_conn.clone(),
+                                        db_folder.id,
+                                        uid,
+                                    ))?;
+                                }
+                            }
 
-                            db::update_job_progress(
-                                db_conn.clone(),
-                                job.id,
+                            let before_uid = match oldest_uid {
+                                Some(uid) if uid > 1 => Some(uid),
+                                _ => None,
+                            };
+
+                            if before_uid.is_none() {
+                                tracing::debug!(
+                                    "No older UIDs to backfill for {}",
+                                    db_folder.imap_path
+                                );
+                                return Ok(());
+                            }
+
+                            let all_uids = match imap_client.search_emails(
+                                &db_folder.imap_path,
+                                None,
+                                before_uid,
                                 None,
                                 None,
-                                Some(1),
-                                None,
-                                None,
-                            )
-                            .await?;
+                            ) {
+                                Ok(uids) => uids,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "Failed to search emails in folder '{}': {}. Skipping.",
+                                        db_folder.imap_path,
+                                        e
+                                    );
+                                    return Ok(());
+                                }
+                            };
+
+                            let mut historical_uids = all_uids;
+                            historical_uids.sort_unstable_by(|a, b| b.cmp(a));
+                            historical_uids.truncate(fetch_batch_size);
+                            historical_uids
+                        }
+                    };
+
+                    let uids = handle.block_on(emails::filter_new_uids(
+                        db_conn.clone(),
+                        job.credential_id,
+                        db_folder.id,
+                        &uids,
+                    ))?;
+
+                    tracing::info!(
+                        "Found {} new emails to download in {}",
+                        uids.len(),
+                        db_folder.imap_path
+                    );
+
+                    let mut highest_uid = db_folder.last_synced_uid;
+                    let mut lowest_uid: Option<u32> = None;
+
+                    for uid in uids {
+                        if shutdown_flag.load(Ordering::SeqCst) {
+                            return Ok(());
+                        }
+
+                        match imap_client.fetch_email(&db_folder.imap_path, uid) {
+                            Ok(parsed_email) => {
+                                let to_addresses: Vec<EmailAddress> = parsed_email
+                                    .to_addresses
+                                    .iter()
+                                    .filter_map(|(addr, name)| {
+                                        addr.as_ref().map(|a| EmailAddress {
+                                            email: a.clone(),
+                                            name: name.clone(),
+                                        })
+                                    })
+                                    .collect();
+
+                                let insert_result = handle.block_on(
+                                    db::insert_email_download_transactional(
+                                        db_conn.clone(),
+                                        job.id,
+                                        job.credential_id,
+                                        parsed_email.uid,
+                                        db_folder.id,
+                                        parsed_email.message_id.as_deref(),
+                                        parsed_email.subject.as_deref(),
+                                        &parsed_email.from_address.unwrap_or_default(),
+                                        parsed_email.from_name.as_deref(),
+                                        &to_addresses,
+                                        &[],
+                                        &[],
+                                        parsed_email.reply_to.as_deref(),
+                                        parsed_email.date_sent,
+                                        parsed_email.date_received,
+                                        parsed_email.body_text.as_deref(),
+                                        parsed_email.body_html.as_deref(),
+                                        parsed_email.is_read,
+                                        parsed_email.is_flagged,
+                                        parsed_email.is_draft,
+                                        parsed_email.is_answered,
+                                        parsed_email.has_attachments,
+                                        parsed_email.attachment_count,
+                                        parsed_email.size_bytes,
+                                        &parsed_email.labels,
+                                    ),
+                                );
+
+                                match insert_result {
+                                    Ok((_download_item_id, email_id)) => {
+                                        tracing::info!(
+                                            "Downloaded and stored email UID {} (id: {}) in transaction",
+                                            uid,
+                                            email_id
+                                        );
+                                        highest_uid =
+                                            Some(highest_uid.map_or(uid, |last| last.max(uid)));
+                                        lowest_uid =
+                                            Some(lowest_uid.map_or(uid, |last| last.min(uid)));
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to store email UID {} in transaction: {}",
+                                            uid,
+                                            e
+                                        );
+                                        let _ = handle.block_on(db::update_job_progress(
+                                            db_conn.clone(),
+                                            job.id,
+                                            None,
+                                            None,
+                                            Some(1),
+                                            None,
+                                            None,
+                                        ));
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to download email UID {}: {}", uid, e);
+                                let _ = handle.block_on(db::update_job_progress(
+                                    db_conn.clone(),
+                                    job.id,
+                                    None,
+                                    None,
+                                    Some(1),
+                                    None,
+                                    None,
+                                ));
+                            }
                         }
                     }
-                }
 
-                // Update folder sync state with highest UID processed
-                if let Some(uid) = highest_uid {
-                    folders::update_folder_sync_state(
-                        db_conn.clone(),
-                        db_folder.id,
-                        uid,
-                        uid,
-                    ).await?;
-                    tracing::info!("Updated folder {} sync state to UID {}", db_folder.imap_path, uid);
-                }
-
-                if matches!(job.job_type, JobType::HistoricalBackfill) {
-                    if let Some(uid) = lowest_uid {
-                        folders::update_folder_backfill_state(
+                    if let Some(uid) = highest_uid {
+                        handle.block_on(folders::update_folder_sync_state(
                             db_conn.clone(),
                             db_folder.id,
                             uid,
-                        ).await?;
+                            uid,
+                        ))?;
+                        tracing::info!(
+                            "Updated folder {} sync state to UID {}",
+                            db_folder.imap_path,
+                            uid
+                        );
                     }
-                }
 
-                Ok::<(), anyhow::Error>(())
+                    if matches!(job.job_type, JobType::HistoricalBackfill) {
+                        if let Some(uid) = lowest_uid {
+                            handle.block_on(folders::update_folder_backfill_state(
+                                db_conn.clone(),
+                                db_folder.id,
+                                uid,
+                            ))?;
+                        }
+                    }
+
+                    Ok::<(), anyhow::Error>(())
+                })
+                .await;
+
+                match result {
+                    Ok(inner) => inner,
+                    Err(e) => Err(anyhow::anyhow!("IMAP blocking task failed: {}", e)),
+                }
             });
         }
 

--- a/dwata-api/src/main.rs
+++ b/dwata-api/src/main.rs
@@ -356,6 +356,7 @@ async fn main() -> std::io::Result<()> {
             .route("/api/financial/extract", web::post().to(handlers::financial::trigger_extraction))
             .route("/api/financial/extractions/summary", web::get().to(handlers::financial::get_extraction_summary))
             .route("/api/financial/extractions/attempts", web::get().to(handlers::financial::list_extraction_attempts))
+            .route("/api/financial/email-scan", web::post().to(handlers::financial::scan_financial_emails))
             .route("/api/financial/patterns", web::get().to(handlers::financial::list_patterns))
             .route("/api/financial/patterns", web::post().to(handlers::financial::create_pattern))
             .route("/api/financial/patterns/{id}", web::get().to(handlers::financial::get_pattern))

--- a/gui/src/index.tsx
+++ b/gui/src/index.tsx
@@ -8,6 +8,7 @@ import Calendar from "./pages/Calendar";
 import Emails from "./pages/Emails";
 import FinancialExtractions from "./pages/FinancialExtractions";
 import FinancialHealth from "./pages/FinancialHealth";
+import FinancialPatternDetection from "./pages/FinancialPatternDetection";
 import FinancialPatterns from "./pages/FinancialPatterns";
 import Projects from "./pages/Projects";
 import Settings from "./pages/Settings";
@@ -34,6 +35,7 @@ render(
       <Route path="/financial" component={FinancialHealth} />
       <Route path="/financial/extractions" component={FinancialExtractions} />
       <Route path="/financial/patterns" component={FinancialPatterns} />
+      <Route path="/financial/patterns/detect" component={FinancialPatternDetection} />
       <Route path="/jobs" component={BackgroundJobs} />
       <Route path="/settings" component={Settings} />
       <Route path="/settings/:tab" component={Settings} />

--- a/gui/src/pages/FinancialPatternDetection.tsx
+++ b/gui/src/pages/FinancialPatternDetection.tsx
@@ -1,0 +1,143 @@
+import { A } from "@solidjs/router";
+import { createSignal, onMount, Show, For } from "solid-js";
+import { HiOutlineArrowPath, HiOutlineSparkles } from "solid-icons/hi";
+import type { FinancialEmailScanResponse } from "../api-types/types";
+import { getApiUrl } from "../config/api";
+import FinancialPageLayout from "../components/FinancialPageLayout";
+
+const emptyResponse: FinancialEmailScanResponse = {
+  total_emails_scanned: 0,
+  total_matched_emails: 0,
+  senders: [],
+};
+
+export default function FinancialPatternDetection() {
+  const [scanResult, setScanResult] =
+    createSignal<FinancialEmailScanResponse>(emptyResponse);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const fetchScan = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(getApiUrl("/api/financial/email-scan"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to run scan: ${response.status}`);
+      }
+
+      const data: FinancialEmailScanResponse = await response.json();
+      setScanResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to run scan");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  onMount(() => {
+    fetchScan();
+  });
+
+  const footerActions = (
+    <>
+      <A href="/financial/patterns" class="btn btn-ghost btn-sm">
+        Back to Patterns
+      </A>
+      <button class="btn btn-primary btn-sm" onClick={fetchScan}>
+        <HiOutlineArrowPath class="w-4 h-4" />
+        Refresh
+      </button>
+    </>
+  );
+
+  return (
+    <FinancialPageLayout
+      title="Financial Overview: Detect Patterns"
+      subtitle="Detect Patterns With AI"
+      footer={footerActions}
+    >
+      <div class="space-y-6">
+        <Show when={error()}>
+          <div class="alert alert-error">
+            <span>{error()}</span>
+          </div>
+        </Show>
+
+        <Show when={loading()}>
+          <div class="flex items-center gap-2 text-sm text-base-content/70">
+            <span class="loading loading-spinner loading-sm"></span>
+            Running scan...
+          </div>
+        </Show>
+
+        <Show when={!loading()}>
+          <div class="stats stats-vertical lg:stats-horizontal shadow bg-base-100">
+            <div class="stat">
+              <div class="stat-figure text-primary">
+                <HiOutlineSparkles class="w-8 h-8" />
+              </div>
+              <div class="stat-title">Emails Scanned</div>
+              <div class="stat-value">
+                {scanResult().total_emails_scanned}
+              </div>
+            </div>
+            <div class="stat">
+              <div class="stat-title">Matched Emails</div>
+              <div class="stat-value text-secondary">
+                {scanResult().total_matched_emails}
+              </div>
+              <div class="stat-desc">
+                Senders matched: {scanResult().senders.length}
+              </div>
+            </div>
+          </div>
+
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <div class="flex items-center justify-between">
+                <h2 class="text-lg font-semibold">Senders by volume</h2>
+                <span class="text-xs text-base-content/60">
+                  {scanResult().senders.length} senders
+                </span>
+              </div>
+              <div class="overflow-x-auto">
+                <table class="table table-zebra">
+                  <thead>
+                    <tr>
+                      <th>Sender</th>
+                      <th class="text-right">Matched Emails</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={scanResult().senders}>
+                      {(sender) => (
+                        <tr>
+                          <td class="font-mono text-xs">
+                            {sender.sender_email}
+                          </td>
+                          <td class="text-right">{sender.matched_count}</td>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+              <Show when={scanResult().senders.length === 0}>
+                <div class="text-sm text-base-content/60">
+                  No matching senders yet.
+                </div>
+              </Show>
+            </div>
+          </div>
+        </Show>
+      </div>
+    </FinancialPageLayout>
+  );
+}

--- a/gui/src/pages/FinancialPatterns.tsx
+++ b/gui/src/pages/FinancialPatterns.tsx
@@ -59,6 +59,12 @@ export default function FinancialPatterns() {
       <A href="/financial" class="btn btn-ghost btn-sm">
         Back to Financial
       </A>
+      <A
+        href="/financial/patterns/detect"
+        class="btn btn-secondary btn-sm"
+      >
+        Detect Patterns With AI
+      </A>
       <button class="btn btn-primary btn-sm" onClick={fetchPatterns}>
         <HiOutlineArrowPath class="w-4 h-4" />
         Refresh
@@ -112,6 +118,7 @@ export default function FinancialPatterns() {
                   <thead>
                     <tr>
                       <th>Name</th>
+                      <th>Sender</th>
                       <th>Document</th>
                       <th>Status</th>
                       <th>Confidence</th>
@@ -133,6 +140,11 @@ export default function FinancialPatterns() {
                                 {pattern.description}
                               </div>
                             </Show>
+                          </td>
+                          <td class="text-xs">
+                            <span class="font-mono">
+                              {pattern.sender_email ?? "—"}
+                            </span>
                           </td>
                           <td>
                             <span class="badge badge-outline">

--- a/shared-types/src/bin/generate_api_types.rs
+++ b/shared-types/src/bin/generate_api_types.rs
@@ -88,6 +88,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     types.push(clean_type(AttachmentExtractionStatus::export_to_string()?));
     types.push(clean_type(ListEmailsRequest::export_to_string()?));
     types.push(clean_type(ListEmailsResponse::export_to_string()?));
+    types.push(clean_type(FinancialEmailScanRequest::export_to_string()?));
+    types.push(clean_type(FinancialEmailScanResponse::export_to_string()?));
+    types.push(clean_type(FinancialEmailScanSender::export_to_string()?));
 
     // Email Folder and Label types
     types.push(clean_type(EmailFolder::export_to_string()?));

--- a/shared-types/src/email.rs
+++ b/shared-types/src/email.rs
@@ -103,3 +103,29 @@ pub struct ListEmailsResponse {
     pub total_count: i64,
     pub has_more: bool,
 }
+
+/// Request to scan emails for financial transaction signals
+#[derive(Debug, Deserialize, TS)]
+#[ts(export)]
+pub struct FinancialEmailScanRequest {
+    pub credential_id: Option<i64>,
+    pub max_emails: Option<usize>,
+    pub max_senders: Option<usize>,
+}
+
+/// Sender summary for financial email scan
+#[derive(Debug, Serialize, TS)]
+#[ts(export)]
+pub struct FinancialEmailScanSender {
+    pub sender_email: String,
+    pub matched_count: i64,
+}
+
+/// Response for financial email scan
+#[derive(Debug, Serialize, TS)]
+#[ts(export)]
+pub struct FinancialEmailScanResponse {
+    pub total_emails_scanned: i64,
+    pub total_matched_emails: i64,
+    pub senders: Vec<FinancialEmailScanSender>,
+}

--- a/shared-types/src/financial.rs
+++ b/shared-types/src/financial.rs
@@ -173,6 +173,7 @@ pub struct FinancialPattern {
     pub name: String,
     pub regex_pattern: String,
     pub description: Option<String>,
+    pub sender_email: Option<String>,
     pub document_type: String,
     pub status: String,
     pub confidence: f32,

--- a/shared-types/src/lib.rs
+++ b/shared-types/src/lib.rs
@@ -34,8 +34,8 @@ pub use download::{
     FileFilter, ImapDownloadState, ImapFolderStatus, ImapSyncStrategy, SourceType,
 };
 pub use email::{
-    AttachmentExtractionStatus, Email, EmailAddress, EmailAttachment, ListEmailsRequest,
-    ListEmailsResponse,
+    AttachmentExtractionStatus, Email, EmailAddress, EmailAttachment, FinancialEmailScanRequest,
+    FinancialEmailScanResponse, FinancialEmailScanSender, ListEmailsRequest, ListEmailsResponse,
 };
 pub use event::{CreateEventRequest, Event, EventsResponse, UpdateEventRequest};
 pub use extraction_job::{


### PR DESCRIPTION
## Summary
- Enable SQLite WAL mode and move DB reads to blocking tasks
- Move credential and financial pattern DB operations off the async runtime
- Run IMAP network operations on blocking threads to avoid runtime starvation

## Testing
- Not run (manual verification: API responsiveness during downloads improved)